### PR TITLE
Handle severity from newer GHCs

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,11 +123,11 @@
   "description": "A Haskell IDE.",
   "devDependencies": {
     "@tsconfig/node16-strictest": "^1.0.4",
-    "@types/node": "^18.11.9",
-    "@types/vscode": "^1.73.0",
-    "esbuild": "^0.15.13",
-    "typescript": "^4.8.4",
-    "vsce": "^2.14.0"
+    "@types/node": "^18.11.18",
+    "@types/vscode": "^1.74.0",
+    "@vscode/vsce": "^2.16.0",
+    "esbuild": "^0.17.0",
+    "typescript": "^4.9.4"
   },
   "displayName": "Purple Yolk",
   "keywords": [
@@ -135,7 +135,7 @@
   ],
   "engines": {
     "node": "^16.14.2",
-    "vscode": "^1.73.1"
+    "vscode": "^1.74.3"
   },
   "homepage": "https://github.com/tfausak/purple-yolk",
   "icon": "data/image/icon.png",

--- a/source/client.ts
+++ b/source/client.ts
@@ -41,7 +41,7 @@ type Key = string
 interface Message {
   doc: string,
   reason: MessageReason | null,
-  severity: MessageSeverity,
+  severity: MessageSeverity | null,
   span: MessageSpan | null,
 }
 
@@ -387,7 +387,8 @@ function messageSpanToRange(span: MessageSpan): vscode.Range {
 
 function messageToDiagnostic(message: Message): vscode.Diagnostic {
   const range = messageSpanToRange(message.span || DEFAULT_MESSAGE_SPAN)
-  const severity = messageSeverityToDiagnostic(message.severity)
+  let severity = vscode.DiagnosticSeverity.Information
+  if (message.severity) { severity = messageSeverityToDiagnostic(message.severity) }
   const diagnostic = new vscode.Diagnostic(range, message.doc, severity)
   if (message.reason) { diagnostic.code = message.reason }
   diagnostic.source = my.name


### PR DESCRIPTION
Older versions of GHC had an explicit `"severity"` key in the message JSON. Newer versions include the severity in a space-separated list under the `"messageClass"` key. I think this change was introduced in GHC 9.4. I'm not sure why I didn't noticed before now. 