### PR TITLE
Only lint Haskell documents

### DIFF
--- a/source/client.ts
+++ b/source/client.ts
@@ -166,7 +166,7 @@ function commandHaskellLint(
   collection: vscode.DiagnosticCollection
 ): void {
   const document = vscode.window.activeTextEditor?.document
-  if (!document) { return }
+  if (!document || document.languageId !== HASKELL_LANGUAGE_ID) { return }
 
   vscode.window.withProgress(
     {


### PR DESCRIPTION
I have noticed in some situations that VSCode attempts to lint non-Haskell documents. I think this happens when:

- you have a dirty Haskell document open; and
- you have a dirty non-Haskell document open and focused; and
- you run the "Save All" command.