### PR TITLE
Allow `cabal-fmt` to format more files by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "configuration": {
       "properties": {
         "purple-yolk.cabal.formatter.command": {
-          "default": "cabal-fmt --no-tabular",
+          "default": "cabal-fmt --no-cabal-file --no-tabular",
           "description": "The command to run when formatting Cabal files. This should accept an unformatted Cabal file as input on STDIN. It should emit a formatted Cabal file to STDOUT. STDERR will be ignored.",
           "type": "string"
         },


### PR DESCRIPTION
By default, `cabal-fmt` only works with `*.cabal` files. If you try to format a file that uses the same syntax, like a `cabal.project` file, you'll get an error like this:

```
Errors encountered when parsing cabal file cabal.project:

cabal.project:0:0: error:
"name" field missing


cabal.project:1:1: warning:
Unknown field: "packages"

    1 | packages: .
      | ^
```

This is a problem for Purple Yolk because it correctly identifies `cabal.project` files as using Cabal syntax, then tries to format them and fails. With these changes, it will be able to format them by default. For example:

``` sh
$ cat cabal.project
packages: .

$ cabal-fmt --no-cabal-file cabal.project
packages: .
```