### PR TITLE
Implement command substitution

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,4 +1,4 @@
 {
   "containerUser": "node",
-  "image": "node:16.14.2"
+  "image": "node:16.17.1"
 }

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
+          node-version: 16.17.1
 
       - run: npm install
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /node_modules/
 /package-lock.json
 /purple-yolk-*.vsix
+/yarn.lock

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Taylor Fausak
+Copyright (c) 2023 Taylor Fausak
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -116,19 +116,19 @@
   "description": "A Haskell IDE.",
   "devDependencies": {
     "@tsconfig/node16-strictest": "^1.0.4",
-    "@types/node": "^18.14.1",
+    "@types/node": "^20.2.3",
     "@types/vscode": "^1.75.1",
     "@vscode/vsce": "^2.17.0",
     "esbuild": "^0.17.10",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.4"
   },
   "displayName": "Purple Yolk",
   "keywords": [
     "haskell"
   ],
   "engines": {
-    "node": "^16.14.2",
-    "vscode": "^1.75.1"
+    "node": "^16.17.1",
+    "vscode": "^1.78.2"
   },
   "homepage": "https://github.com/tfausak/purple-yolk",
   "icon": "data/image/icon.png",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,5 @@
 {
   "//": "https://code.visualstudio.com/api/references/extension-manifest",
-  "activationEvents": [
-    "onCommand:purple-yolk.haskell.interpret",
-    "onCommand:purple-yolk.haskell.lint",
-    "onCommand:purple-yolk.output.show",
-    "onLanguage:cabal",
-    "onLanguage:haskell"
-  ],
   "badges": [
     {
       "description": "Build status",
@@ -123,11 +116,11 @@
   "description": "A Haskell IDE.",
   "devDependencies": {
     "@tsconfig/node16-strictest": "^1.0.4",
-    "@types/node": "^18.11.18",
-    "@types/vscode": "^1.74.0",
-    "@vscode/vsce": "^2.16.0",
-    "esbuild": "^0.17.0",
-    "typescript": "^4.9.4"
+    "@types/node": "^18.14.1",
+    "@types/vscode": "^1.75.1",
+    "@vscode/vsce": "^2.17.0",
+    "esbuild": "^0.17.10",
+    "typescript": "^4.9.5"
   },
   "displayName": "Purple Yolk",
   "keywords": [
@@ -135,7 +128,7 @@
   ],
   "engines": {
     "node": "^16.14.2",
-    "vscode": "^1.74.3"
+    "vscode": "^1.75.1"
   },
   "homepage": "https://github.com/tfausak/purple-yolk",
   "icon": "data/image/icon.png",

--- a/source/client.ts
+++ b/source/client.ts
@@ -204,15 +204,11 @@ function expandTemplate(
   replacements: { [key: string]: string }
 ): string {
   return template
-    .replace(/(\\*)\$\{([a-z]+)\}/, (match, slashes, key) => {
-      if (slashes.length % 2 !== 0) {
-        return match.slice(1)
-      }
+    .replace(/\$\{(.*?)\}/, (_, key) => {
       const value = replacements[key]
       if (typeof value === 'undefined') { throw `unknown variable: ${key}` }
-      return `${slashes.slice(1)}${value}`
+      return value
     })
-    .replace('\\$\{([a-z]+)\}', (_, key) => `\${${key}}`)
 }
 
 async function formatDocumentRange(

--- a/source/client.ts
+++ b/source/client.ts
@@ -210,7 +210,7 @@ function expandTemplate(
       }
       const value = replacements[key]
       if (typeof value === 'undefined') { throw `unknown variable: ${key}` }
-      return `${slashes.slice(2)}${value}`
+      return `${slashes.slice(1)}${value}`
     })
     .replace('\\$\{([a-z]+)\}', (_, key) => `\${${key}}`)
 }

--- a/source/client.ts
+++ b/source/client.ts
@@ -204,10 +204,13 @@ function expandTemplate(
   replacements: { [key: string]: string }
 ): string {
   return template
-    .replace(/(?<!\\)\$\{([a-z]+)\}/, (_, key) => {
+    .replace(/(\\*)\$\{([a-z]+)\}/, (match, slashes, key) => {
+      if (slashes.length % 2 !== 0) {
+        return match.slice(1)
+      }
       const value = replacements[key]
       if (typeof value === 'undefined') { throw `unknown variable: ${key}` }
-      return value
+      return `${slashes.slice(2)}${value}`
     })
     .replace('\\$\{([a-z]+)\}', (_, key) => `\${${key}}`)
 }


### PR DESCRIPTION
The goal here is to interpret commands like template string literals. So if you configure the linter command to `hlint ${file}`, the `${file}` bit will be expanded to the actual file path when the linter runs. 

I'm opening this as a draft for a few reasons:

- Did I do escaping properly? I think you should be able to write `\${file}` to mean a literal `${file}`. 
- What should I do for unknown "variables"? Right now it's just `file`, but that could easily be expanded in the future. For example I might also provide the directory later on. 
- Does it even make sense to provide this? If you have unsaved changes in a file buffer, any file-based commands will behave weirdly. 