### PR TITLE
Improve configuration

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,4 +1,4 @@
 {
   "containerUser": "node",
-  "image": "node:16.17.1"
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:16"
 }

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,19 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily
+{
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "github-actions",
+      "schedule": {
+        "interval": "daily"
+      }
+    },
+    {
+      "directory": "/",
+      "package-ecosystem": "npm",
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,38 +1,57 @@
-name: Workflow
-on:
-  push: null
-  release:
-    types:
-      - created
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16.17.1
-
-      - run: npm install
-
-      - run: npx vsce package --out purple-yolk.vsix
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: purple-yolk-${{ github.sha }}.vsix
-          path: purple-yolk.vsix
-
-      - if: github.event_name == 'release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_content_type: application/vsix
-          asset_name: purple-yolk-${{ github.event.release.tag_name }}.vsix
-          asset_path: purple-yolk.vsix
-          upload_url: ${{ github.event.release.upload_url }}
-
-      - if: github.event_name == 'release'
-        run: npx vsce publish --packagePath purple-yolk.vsix --pat "${{ secrets.AZURE_PERSONAL_ACCESS_TOKEN }}"
+{
+  "jobs": {
+    "build": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v3"
+        },
+        {
+          "uses": "actions/setup-node@v3",
+          "with": {
+            "node-version": "16.17.1"
+          }
+        },
+        {
+          "run": "npm install"
+        },
+        {
+          "run": "npx vsce package --out purple-yolk.vsix"
+        },
+        {
+          "uses": "actions/upload-artifact@v3",
+          "with": {
+            "name": "purple-yolk-${{ github.sha }}.vsix",
+            "path": "purple-yolk.vsix"
+          }
+        },
+        {
+          "env": {
+            "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+          },
+          "if": "github.event_name == 'release'",
+          "uses": "actions/upload-release-asset@v1",
+          "with": {
+            "asset_content_type": "application/vsix",
+            "asset_name": "purple-yolk-${{ github.event.release.tag_name }}.vsix",
+            "asset_path": "purple-yolk.vsix",
+            "upload_url": "${{ github.event.release.upload_url }}"
+          }
+        },
+        {
+          "if": "github.event_name == 'release'",
+          "run": "npx vsce publish --packagePath purple-yolk.vsix --pat \"${{ secrets.AZURE_PERSONAL_ACCESS_TOKEN }}\""
+        }
+      ]
+    }
+  },
+  "name": "Workflow",
+  "on": {
+    "push": null,
+    "release": {
+      "types": [
+        "created"
+      ]
+    }
+  }
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,9 @@
 # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#using-.vscodeignore
-.github/
-.vscode/
-node_modules/
-source/
+**/*
+
+!data/
+!dist/
+!CHANGELOG.md
+!LICENSE.txt
+!package.json
+!README.md

--- a/data/grammar/haskell.json
+++ b/data/grammar/haskell.json
@@ -80,6 +80,10 @@
       "match": "\\b(?:[0-9]+[eE][+-]?[0-9]+|[0-9]+[.][0-9]+(?:[eE][+-]?[0-9]+)?|0[oO][0-7]+|0[xX][0-9A-Fa-f]+|[0-9]+)\\b",
       "name": "constant.numeric.haskell"
     },
+    "operator": {
+      "match": "\\~|\\`|\\!|\\@|\\#|\\$|\\%|\\^|\\&|\\*|\\(|\\)|\\-|\\_|\\+|\\=|\\{|\\}|\\[|\\]|\\\\|\\:|\\;|\\'|\\<|\\>|\\,|\\.|\\/|\\?",
+      "name": "keyword.operator.haskell"
+    },
     "reserved": {
       "patterns": [
         {
@@ -118,10 +122,6 @@
         }
       },
       "match": "(^[ \\t]*\\\\|\\\\[ \\t]+\\\\|\\\\[ \\t]*$)|[^\"\\\\\\n\\r]|(\\\\(?:[abfnrtv\\\\\"'&]|\\^[A-Z@\\[\\\\\\]\\^_]|(?:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL)|[0-9]+|o[0-7]+|x[0-9A-Fa-f]+))"
-    },
-    "operator": {
-      "match": "\\~|\\`|\\!|\\@|\\#|\\$|\\%|\\^|\\&|\\*|\\(|\\)|\\-|\\_|\\+|\\=|\\{|\\}|\\[|\\]|\\\\|\\:|\\;|\\'|\\<|\\>|\\,|\\.|\\/|\\?",
-      "name": "keyword.operator.haskell"
     }
   },
   "scopeName": "source.haskell"

--- a/package.json
+++ b/package.json
@@ -41,8 +41,28 @@
           "type": "string"
         },
         "purple-yolk.haskell.formatter.command": {
-          "default": "ormolu --no-cabal",
+          "default": "",
           "description": "The command to run when formatting Haskell files. This should accept an unformatted Haskell file as input on STDIN. It should emit a formatted Haskell file to STDOUT. STDERR will be ignored.",
+          "type": "string"
+        },
+        "purple-yolk.haskell.formatter.mode": {
+          "default": "discover",
+          "description": "The command to format a Haskell file.",
+          "enum": [
+            "discover",
+            "ormolu",
+            "custom"
+          ],
+          "enumItemLabels": [
+            "Discover",
+            "Ormolu",
+            "Custom"
+          ],
+          "markdownEnumDescriptions": [
+            "Automatically determines the appropriate command.",
+            "Uses `ormolu`.",
+            "Uses the command in `#purple-yolk.haskell.formatter.command#`."
+          ],
           "type": "string"
         },
         "purple-yolk.haskell.interpreter.command": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
           "type": "string"
         },
         "purple-yolk.haskell.interpreter.command": {
+          "default": "",
+          "markdownDescription": "This should pass `-ddump-json` to GHC.",
+          "type": "string"
+        },
+        "purple-yolk.haskell.interpreter.mode": {
           "default": "discover",
           "description": "The command to launch a Haskell interpreter.",
           "enum": [
@@ -69,11 +74,6 @@
             "Uses `ghci`. Only works with a single file.",
             "Uses the command in `#purple-yolk.haskell.interpreter.custom#`."
           ],
-          "type": "string"
-        },
-        "purple-yolk.haskell.interpreter.custom": {
-          "default": "",
-          "markdownDescription": "This should pass `-ddump-json` to GHC.",
           "type": "string"
         },
         "purple-yolk.haskell.linter.command": {

--- a/package.json
+++ b/package.json
@@ -70,16 +70,19 @@
           "description": "The command to format a Haskell file.",
           "enum": [
             "discover",
+            "fourmolu",
             "ormolu",
             "custom"
           ],
           "enumItemLabels": [
             "Discover",
+            "Fourmolu",
             "Ormolu",
             "Custom"
           ],
           "markdownEnumDescriptions": [
             "Automatically determines the appropriate command.",
+            "Uses `fourmolu`.",
             "Uses `ormolu`.",
             "Uses the command in `#purple-yolk.haskell.formatter.command#`."
           ],

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
           "type": "string"
         },
         "purple-yolk.haskell.linter.onSave": {
-          "default": true,
+          "default": false,
           "description": "Should the linter be run automatically on save?",
           "type": "boolean"
         }

--- a/package.json
+++ b/package.json
@@ -54,17 +54,17 @@
             "ghci",
             "custom"
           ],
-          "markdownEnumDescriptions": [
-            "Uses `cabal repl`.",
-            "Uses `stack ghci`.",
-            "Uses `ghci`. Only works with a single file.",
-            "Uses the command in `#purple-yolk.haskell.interpreter.custom#`."
-          ],
           "enumItemLabels": [
             "Cabal",
             "Stack",
             "GHCi",
             "Custom"
+          ],
+          "markdownEnumDescriptions": [
+            "Uses `cabal repl`.",
+            "Uses `stack ghci`.",
+            "Uses `ghci`. Only works with a single file.",
+            "Uses the command in `#purple-yolk.haskell.interpreter.custom#`."
           ],
           "type": "string"
         },
@@ -147,15 +147,15 @@
     "typescript": "^5.0.4"
   },
   "displayName": "Purple Yolk",
-  "keywords": [
-    "haskell"
-  ],
   "engines": {
     "node": "^16.17.1",
     "vscode": "^1.81.1"
   },
   "homepage": "https://github.com/tfausak/purple-yolk",
   "icon": "data/image/icon.png",
+  "keywords": [
+    "haskell"
+  ],
   "license": "MIT",
   "main": "dist/client.js",
   "name": "purple-yolk",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,31 @@
           "type": "string"
         },
         "purple-yolk.haskell.interpreter.command": {
-          "default": "cabal repl --repl-options -ddump-json",
-          "description": "The command to launch a Haskell interpreter. This should be something like `cabal repl` or `stack ghci`. It should also pass `-ddump-json` to GHCi.",
+          "default": "cabal",
+          "description": "The command to launch a Haskell interpreter.",
+          "enum": [
+            "cabal",
+            "stack",
+            "ghci",
+            "custom"
+          ],
+          "markdownEnumDescriptions": [
+            "Uses `cabal repl`.",
+            "Uses `stack ghci`.",
+            "Uses `ghci`. Only works with a single file.",
+            "Uses the command in `#purple-yolk.haskell.interpreter.custom#`."
+          ],
+          "enumItemLabels": [
+            "Cabal",
+            "Stack",
+            "GHCi",
+            "Custom"
+          ],
+          "type": "string"
+        },
+        "purple-yolk.haskell.interpreter.custom": {
+          "default": "",
+          "markdownDescription": "This should pass `-ddump-json` to GHC.",
           "type": "string"
         },
         "purple-yolk.haskell.linter.command": {

--- a/package.json
+++ b/package.json
@@ -46,21 +46,24 @@
           "type": "string"
         },
         "purple-yolk.haskell.interpreter.command": {
-          "default": "cabal",
+          "default": "discover",
           "description": "The command to launch a Haskell interpreter.",
           "enum": [
+            "discover",
             "cabal",
             "stack",
             "ghci",
             "custom"
           ],
           "enumItemLabels": [
+            "Discover",
             "Cabal",
             "Stack",
             "GHCi",
             "Custom"
           ],
           "markdownEnumDescriptions": [
+            "Automatically determines the appropriate command.",
             "Uses `cabal repl`.",
             "Uses `stack ghci`.",
             "Uses `ghci`. Only works with a single file.",
@@ -142,9 +145,11 @@
     "@tsconfig/strictest": "^2.0.1",
     "@types/node": "^20.2.3",
     "@types/vscode": "^1.75.1",
+    "@types/which": "^3.0.0",
     "@vscode/vsce": "^2.17.0",
     "esbuild": "^0.19.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "which": "^4.0.0"
   },
   "displayName": "Purple Yolk",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,26 @@
           "description": "The command to run when formatting Cabal files. This should accept an unformatted Cabal file as input on STDIN. It should emit a formatted Cabal file to STDOUT. STDERR will be ignored.",
           "type": "string"
         },
+        "purple-yolk.cabal.formatter.mode": {
+          "default": "discover",
+          "description": "The command to format a Cabal file.",
+          "enum": [
+            "discover",
+            "cabal-fmt",
+            "custom"
+          ],
+          "enumItemLabels": [
+            "Discover",
+            "cabal-fmt",
+            "Custom"
+          ],
+          "markdownEnumDescriptions": [
+            "Automatically determines the appropriate command.",
+            "Uses `cabal-fmt`.",
+            "Uses the command in `#purple-yolk.cabal.formatter.command#`."
+          ],
+          "type": "string"
+        },
         "purple-yolk.haskell.formatter.command": {
           "default": "",
           "description": "The command to run when formatting Haskell files. This should accept an unformatted Haskell file as input on STDIN. It should emit a formatted Haskell file to STDOUT. STDERR will be ignored.",

--- a/package.json
+++ b/package.json
@@ -97,8 +97,28 @@
           "type": "string"
         },
         "purple-yolk.haskell.linter.command": {
-          "default": "hlint --json --no-exit-code -",
+          "default": "",
           "description": "The command to run when linting Haskell files. This should accept a Haskell file as input on STDIN. It should emit HLint ideas formatted as JSON to STDOUT. STDERR will be ignored.",
+          "type": "string"
+        },
+        "purple-yolk.haskell.linter.mode": {
+          "default": "discover",
+          "description": "The command to lint a Haskell file.",
+          "enum": [
+            "discover",
+            "hlint",
+            "custom"
+          ],
+          "enumItemLabels": [
+            "Discover",
+            "HLint",
+            "Custom"
+          ],
+          "markdownEnumDescriptions": [
+            "Automatically determines the appropriate command.",
+            "Uses `hlint`.",
+            "Uses the command in `#purple-yolk.haskell.linter.command#`."
+          ],
           "type": "string"
         },
         "purple-yolk.haskell.linter.onSave": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "configuration": {
       "properties": {
         "purple-yolk.cabal.formatter.command": {
-          "default": "cabal-fmt --no-cabal-file --no-tabular",
+          "default": "",
           "description": "The command to run when formatting Cabal files. This should accept an unformatted Cabal file as input on STDIN. It should emit a formatted Cabal file to STDOUT. STDERR will be ignored.",
           "type": "string"
         },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
   },
   "description": "A Haskell IDE.",
   "devDependencies": {
-    "@tsconfig/node16-strictest": "^1.0.4",
+    "@tsconfig/node16": "^16.1.1",
+    "@tsconfig/strictest": "^2.0.1",
     "@types/node": "^20.2.3",
     "@types/vscode": "^1.75.1",
     "@vscode/vsce": "^2.17.0",

--- a/source/client.ts
+++ b/source/client.ts
@@ -6,6 +6,7 @@ import readline from "readline";
 import vscode from "vscode";
 import which from "which";
 
+import CabalFormatterMode from "./type/CabalFormatterMode";
 import HaskellFormatterMode from "./type/HaskellFormatterMode";
 import HaskellLinterMode from "./type/HaskellLinterMode";
 import Idea from "./type/Idea";
@@ -27,12 +28,6 @@ const DEFAULT_MESSAGE_SPAN: MessageSpan = {
   startCol: 1,
   startLine: 1,
 };
-
-const CABAL_FORMATTER_MODE_DISCOVER = "discover";
-
-const CABAL_FORMATTER_MODE_CABAL_FMT = "cabal-fmt";
-
-const CABAL_FORMATTER_MODE_CUSTOM = "custom";
 
 let INTERPRETER: Interpreter | null = null;
 
@@ -184,24 +179,24 @@ async function setCabalFormatterTemplate(
   const key = newKey();
   log(channel, key, "Getting Cabal formatter ...");
 
-  let mode: string | undefined = vscode.workspace
+  let mode: CabalFormatterMode | undefined = vscode.workspace
     .getConfiguration(my.name)
     .get(`${LanguageId.Cabal}.formatter.mode`);
   log(channel, key, `Requested mode is ${mode}`);
 
-  if (mode === CABAL_FORMATTER_MODE_DISCOVER) {
+  if (mode === CabalFormatterMode.Discover) {
     const cabalFmt = await which("cabal-fmt", { nothrow: true });
     if (cabalFmt) {
-      mode = CABAL_FORMATTER_MODE_CABAL_FMT;
+      mode = CabalFormatterMode.CabalFmt;
     }
   }
   log(channel, key, `Actual mode is ${mode}`);
 
   switch (mode) {
-    case CABAL_FORMATTER_MODE_CABAL_FMT:
+    case CabalFormatterMode.CabalFmt:
       CABAL_FORMATTER_TEMPLATE = "cabal-fmt --no-cabal-file --no-tabular";
       break;
-    case CABAL_FORMATTER_MODE_CUSTOM:
+    case CabalFormatterMode.Custom:
       CABAL_FORMATTER_TEMPLATE = vscode.workspace
         .getConfiguration(my.name)
         .get(`${LanguageId.Cabal}.formatter.command`);

--- a/source/client.ts
+++ b/source/client.ts
@@ -7,6 +7,7 @@ import vscode from "vscode";
 import which from "which";
 
 import HaskellFormatterMode from "./type/HaskellFormatterMode";
+import HaskellLinterMode from "./type/HaskellLinterMode";
 import Idea from "./type/Idea";
 import IdeaSeverity from "./type/IdeaSeverity";
 import Interpreter from "./type/Interpreter";
@@ -26,12 +27,6 @@ const DEFAULT_MESSAGE_SPAN: MessageSpan = {
   startCol: 1,
   startLine: 1,
 };
-
-const HASKELL_LINTER_MODE_DISCOVER = "discover";
-
-const HASKELL_LINTER_MODE_HLINT = "hlint";
-
-const HASKELL_LINTER_MODE_CUSTOM = "custom";
 
 const CABAL_FORMATTER_MODE_DISCOVER = "discover";
 
@@ -155,24 +150,24 @@ async function setHaskellLinterTemplate(
   const key = newKey();
   log(channel, key, "Getting Haskell linter ...");
 
-  let mode: string | undefined = vscode.workspace
+  let mode: HaskellLinterMode | undefined = vscode.workspace
     .getConfiguration(my.name)
     .get(`${LanguageId.Haskell}.linter.mode`);
   log(channel, key, `Requested mode is ${mode}`);
 
-  if (mode === HASKELL_LINTER_MODE_DISCOVER) {
+  if (mode === HaskellLinterMode.Discover) {
     const hlint = await which("hlint", { nothrow: true });
     if (hlint) {
-      mode = HASKELL_LINTER_MODE_HLINT;
+      mode = HaskellLinterMode.Hlint;
     }
   }
   log(channel, key, `Actual mode is ${mode}`);
 
   switch (mode) {
-    case HASKELL_LINTER_MODE_HLINT:
+    case HaskellLinterMode.Hlint:
       HASKELL_LINTER_TEMPLATE = "hlint --json --no-exit-code -";
       break;
-    case HASKELL_LINTER_MODE_CUSTOM:
+    case HaskellLinterMode.Custom:
       HASKELL_LINTER_TEMPLATE = vscode.workspace
         .getConfiguration(my.name)
         .get(`${LanguageId.Haskell}.linter.command`);

--- a/source/client.ts
+++ b/source/client.ts
@@ -121,7 +121,9 @@ let HASKELL_LINTER_TEMPLATE: string | undefined = undefined;
 
 let CABAL_FORMATTER_TEMPLATE: string | undefined = undefined;
 
-async function setInterpreterTemplate( channel: vscode.OutputChannel ): Promise<void> {
+async function setInterpreterTemplate(
+  channel: vscode.OutputChannel
+): Promise<void> {
   const key = newKey();
   log(channel, key, "Getting Haskell interpreter ...");
 
@@ -131,21 +133,15 @@ async function setInterpreterTemplate( channel: vscode.OutputChannel ): Promise<
   log(channel, key, `Requested mode is ${mode}`);
 
   if (mode === INTERPRETER_MODE_DISCOVER) {
-    const [cabal, [cabalProject], stack, [stackYaml], ghci] = await Promise.all([
-      which("cabal", { nothrow: true }),
-      vscode.workspace.findFiles(
-        "cabal.project",
-        undefined,
-        1
-      ),
-      which("stack", { nothrow: true }),
-      vscode.workspace.findFiles(
-        "stack.yaml",
-        undefined,
-        1
-      ),
-      which("ghci", { nothrow: true }),
-    ]);
+    const [cabal, [cabalProject], stack, [stackYaml], ghci] = await Promise.all(
+      [
+        which("cabal", { nothrow: true }),
+        vscode.workspace.findFiles("cabal.project", undefined, 1),
+        which("stack", { nothrow: true }),
+        vscode.workspace.findFiles("stack.yaml", undefined, 1),
+        which("ghci", { nothrow: true }),
+      ]
+    );
 
     if (cabal && !stack) {
       // If the user only has Cabal available, then use Cabal.
@@ -191,7 +187,9 @@ async function setInterpreterTemplate( channel: vscode.OutputChannel ): Promise<
   }
 }
 
-async function setHaskellFormatterTemplate( channel: vscode.OutputChannel ): Promise<void> {
+async function setHaskellFormatterTemplate(
+  channel: vscode.OutputChannel
+): Promise<void> {
   const key = newKey();
   log(channel, key, "Getting Haskell formatter ...");
 
@@ -223,7 +221,9 @@ async function setHaskellFormatterTemplate( channel: vscode.OutputChannel ): Pro
   }
 }
 
-async function setHaskellLinterTemplate( channel: vscode.OutputChannel ): Promise<void> {
+async function setHaskellLinterTemplate(
+  channel: vscode.OutputChannel
+): Promise<void> {
   const key = newKey();
   log(channel, key, "Getting Haskell linter ...");
 
@@ -255,7 +255,9 @@ async function setHaskellLinterTemplate( channel: vscode.OutputChannel ): Promis
   }
 }
 
-async function setCabalFormatterTemplate( channel: vscode.OutputChannel ): Promise<void> {
+async function setCabalFormatterTemplate(
+  channel: vscode.OutputChannel
+): Promise<void> {
   const key = newKey();
   log(channel, key, "Getting Cabal formatter ...");
 
@@ -362,7 +364,7 @@ export async function activate(
     setHaskellFormatterTemplate(channel),
     setHaskellLinterTemplate(channel),
     setCabalFormatterTemplate(channel),
-  ])
+  ]);
   vscode.workspace.onDidChangeConfiguration(async (e) => {
     const promises = [];
 

--- a/source/client.ts
+++ b/source/client.ts
@@ -121,10 +121,8 @@ let HASKELL_LINTER_TEMPLATE: string | undefined = undefined;
 
 let CABAL_FORMATTER_TEMPLATE: string | undefined = undefined;
 
-async function setInterpreterTemplate(
-  channel: vscode.OutputChannel,
-  key: Key
-): Promise<void> {
+async function setInterpreterTemplate( channel: vscode.OutputChannel ): Promise<void> {
+  const key = newKey();
   log(channel, key, "Getting Haskell interpreter ...");
 
   let mode: string | undefined = vscode.workspace
@@ -193,10 +191,8 @@ async function setInterpreterTemplate(
   }
 }
 
-async function setHaskellFormatterTemplate(
-  channel: vscode.OutputChannel,
-  key: Key
-): Promise<void> {
+async function setHaskellFormatterTemplate( channel: vscode.OutputChannel ): Promise<void> {
+  const key = newKey();
   log(channel, key, "Getting Haskell formatter ...");
 
   let mode: string | undefined = vscode.workspace
@@ -227,10 +223,8 @@ async function setHaskellFormatterTemplate(
   }
 }
 
-async function setHaskellLinterTemplate(
-  channel: vscode.OutputChannel,
-  key: Key
-): Promise<void> {
+async function setHaskellLinterTemplate( channel: vscode.OutputChannel ): Promise<void> {
+  const key = newKey();
   log(channel, key, "Getting Haskell linter ...");
 
   let mode: string | undefined = vscode.workspace
@@ -261,10 +255,8 @@ async function setHaskellLinterTemplate(
   }
 }
 
-async function setCabalFormatterTemplate(
-  channel: vscode.OutputChannel,
-  key: Key
-): Promise<void> {
+async function setCabalFormatterTemplate( channel: vscode.OutputChannel ): Promise<void> {
+  const key = newKey();
   log(channel, key, "Getting Cabal formatter ...");
 
   let mode: string | undefined = vscode.workspace
@@ -365,37 +357,37 @@ export async function activate(
     });
   });
 
-  await setInterpreterTemplate(channel, key);
-  await setHaskellFormatterTemplate(channel, key);
-  await setHaskellLinterTemplate(channel, key);
-  await setCabalFormatterTemplate(channel, key);
+  await setInterpreterTemplate(channel);
+  await setHaskellFormatterTemplate(channel);
+  await setHaskellLinterTemplate(channel);
+  await setCabalFormatterTemplate(channel);
   vscode.workspace.onDidChangeConfiguration(async (e) => {
     const affectsHaskellInterpreter = e.affectsConfiguration(
       `${my.name}.${HASKELL_LANGUAGE_ID}.interpreter`
     );
     if (affectsHaskellInterpreter) {
-      await setInterpreterTemplate(channel, key);
+      await setInterpreterTemplate(channel);
     }
 
     const affectsHaskellFormatter = e.affectsConfiguration(
       `${my.name}.${HASKELL_LANGUAGE_ID}.formatter`
     );
     if (affectsHaskellFormatter) {
-      await setHaskellFormatterTemplate(channel, key);
+      await setHaskellFormatterTemplate(channel);
     }
 
     const affectsHaskellLinter = e.affectsConfiguration(
       `${my.name}.${HASKELL_LANGUAGE_ID}.linter`
     );
     if (affectsHaskellLinter) {
-      await setHaskellLinterTemplate(channel, key);
+      await setHaskellLinterTemplate(channel);
     }
 
     const affectsCabalFormatter = e.affectsConfiguration(
       `${my.name}.${CABAL_LANGUAGE_ID}.formatter`
     );
     if (affectsCabalFormatter) {
-      await setCabalFormatterTemplate(channel, key);
+      await setCabalFormatterTemplate(channel);
     }
   });
 

--- a/source/client.ts
+++ b/source/client.ts
@@ -1,73 +1,73 @@
-import assert from 'assert'
-import childProcess from 'child_process'
-import path from 'path'
-import perfHooks from 'perf_hooks'
-import readline from 'readline'
-import vscode from 'vscode'
+import assert from "assert";
+import childProcess from "child_process";
+import path from "path";
+import perfHooks from "perf_hooks";
+import readline from "readline";
+import vscode from "vscode";
 
-import my from '../package.json'
+import my from "../package.json";
 
 // https://hackage.haskell.org/package/hlint-3.6.1/docs/Language-Haskell-HLint.html#t:Idea
 interface Idea {
-  decl: string[],
-  endColumn: number,
-  endLine: number,
-  file: string,
-  from: string,
-  hint: string,
-  module: string[],
-  note: string[],
-  refactorings: string,
-  severity: IdeaSeverity,
-  startColumn: number,
-  startLine: number,
-  to: string | null,
+  decl: string[];
+  endColumn: number;
+  endLine: number;
+  file: string;
+  from: string;
+  hint: string;
+  module: string[];
+  note: string[];
+  refactorings: string;
+  severity: IdeaSeverity;
+  startColumn: number;
+  startLine: number;
+  to: string | null;
 }
 
 // https://hackage.haskell.org/package/hlint-3.6.1/docs/Language-Haskell-HLint.html#t:Severity
 enum IdeaSeverity {
-  Ignore = 'Ignore',
-  Suggestion = 'Suggestion',
-  Warning = 'Warning',
-  Error = 'Error',
+  Ignore = "Ignore",
+  Suggestion = "Suggestion",
+  Warning = "Warning",
+  Error = "Error",
 }
 
 interface Interpreter {
-  key: Key | null,
-  task: childProcess.ChildProcess,
+  key: Key | null;
+  task: childProcess.ChildProcess;
 }
 
-type Key = string
+type Key = string;
 
 interface Message {
-  doc: string,
-  messageClass: string | null, // Used by GHC >= 9.4.
-  reason: MessageReason | null,
-  severity: MessageSeverity | null, // Used by GHC < 9.4.
-  span: MessageSpan | null,
+  doc: string;
+  messageClass: string | null; // Used by GHC >= 9.4.
+  reason: MessageReason | null;
+  severity: MessageSeverity | null; // Used by GHC < 9.4.
+  span: MessageSpan | null;
 }
 
 // https://downloads.haskell.org/ghc/9.6.2/docs/libraries/ghc-9.6.2/GHC-Driver-Flags.html#t:WarningFlag
-type MessageReason = string
+type MessageReason = string;
 
 // https://downloads.haskell.org/ghc/9.6.2/docs/libraries/ghc-9.6.2/GHC-Types-Error.html#t:Severity
 enum MessageSeverity {
-  SevDump = 'SevDump',
-  SevError = 'SevError',
-  SevFatal = 'SevFatal',
-  SevInfo = 'SevInfo',
-  SevInteractive = 'SevInteractive',
-  SevOutput = 'SevOutput',
-  SevWarning = 'SevWarning',
+  SevDump = "SevDump",
+  SevError = "SevError",
+  SevFatal = "SevFatal",
+  SevInfo = "SevInfo",
+  SevInteractive = "SevInteractive",
+  SevOutput = "SevOutput",
+  SevWarning = "SevWarning",
 }
 
 // https://downloads.haskell.org/ghc/9.6.2/docs/libraries/ghc-9.6.2/GHC-Types-SrcLoc.html#t:SrcSpan
 interface MessageSpan {
-  endCol: number,
-  endLine: number,
-  file: string, // Can be `"<interactive>"`.
-  startCol: number,
-  startLine: number,
+  endCol: number;
+  endLine: number;
+  file: string; // Can be `"<interactive>"`.
+  startCol: number;
+  startLine: number;
 }
 
 const DEFAULT_MESSAGE_SPAN: MessageSpan = {
@@ -76,79 +76,87 @@ const DEFAULT_MESSAGE_SPAN: MessageSpan = {
   file: "<interactive>",
   startCol: 1,
   startLine: 1,
-}
+};
 
-let INTERPRETER: Interpreter | null = null
+let INTERPRETER: Interpreter | null = null;
 
-const CABAL_LANGUAGE_ID = 'cabal'
+const CABAL_LANGUAGE_ID = "cabal";
 
-const HASKELL_LANGUAGE_ID = 'haskell'
+const HASKELL_LANGUAGE_ID = "haskell";
 
 export function activate(context: vscode.ExtensionContext): void {
-  const channel = vscode.window.createOutputChannel(my.displayName)
-  const key = newKey()
-  const start = perfHooks.performance.now()
-  log(channel, key, `Activating ${my.name} version ${my.version} ...`)
+  const channel = vscode.window.createOutputChannel(my.displayName);
+  const key = newKey();
+  const start = perfHooks.performance.now();
+  log(channel, key, `Activating ${my.name} version ${my.version} ...`);
 
-  const interpreterCollection = vscode.languages.createDiagnosticCollection(my.name)
-  const linterCollection = vscode.languages.createDiagnosticCollection(my.name)
+  const interpreterCollection = vscode.languages.createDiagnosticCollection(
+    my.name
+  );
+  const linterCollection = vscode.languages.createDiagnosticCollection(my.name);
 
-  const status = vscode.languages.createLanguageStatusItem(my.name, HASKELL_LANGUAGE_ID)
-  status.command = { command: `${my.name}.output.show`, title: 'Show Output' }
-  status.text = 'Idle'
-  status.name = my.displayName
+  const status = vscode.languages.createLanguageStatusItem(
+    my.name,
+    HASKELL_LANGUAGE_ID
+  );
+  status.command = { command: `${my.name}.output.show`, title: "Show Output" };
+  status.text = "Idle";
+  status.name = my.displayName;
 
-  context.subscriptions.push(vscode.commands.registerCommand(
-    `${my.name}.${HASKELL_LANGUAGE_ID}.interpret`,
-    () => commandHaskellInterpret(channel, status, interpreterCollection)))
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      `${my.name}.${HASKELL_LANGUAGE_ID}.interpret`,
+      () => commandHaskellInterpret(channel, status, interpreterCollection)
+    )
+  );
 
-  context.subscriptions.push(vscode.commands.registerCommand(
-    `${my.name}.${HASKELL_LANGUAGE_ID}.lint`,
-    () => commandHaskellLint(channel, linterCollection)))
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      `${my.name}.${HASKELL_LANGUAGE_ID}.lint`,
+      () => commandHaskellLint(channel, linterCollection)
+    )
+  );
 
-  context.subscriptions.push(vscode.commands.registerCommand(
-    `${my.name}.output.show`,
-    () => commandOutputShow(channel)))
+  context.subscriptions.push(
+    vscode.commands.registerCommand(`${my.name}.output.show`, () =>
+      commandOutputShow(channel)
+    )
+  );
 
   vscode.workspace.onDidSaveTextDocument((document) => {
     switch (document.languageId) {
       case HASKELL_LANGUAGE_ID:
-        reloadInterpreter(channel, status, interpreterCollection)
+        reloadInterpreter(channel, status, interpreterCollection);
 
         const shouldLint: boolean | undefined = vscode.workspace
           .getConfiguration(my.name)
-          .get(`${HASKELL_LANGUAGE_ID}.linter.onSave`)
-        if (shouldLint) { commandHaskellLint(channel, linterCollection) }
+          .get(`${HASKELL_LANGUAGE_ID}.linter.onSave`);
+        if (shouldLint) {
+          commandHaskellLint(channel, linterCollection);
+        }
 
-        break
+        break;
     }
-  })
+  });
 
-  const languageIds = [
-    CABAL_LANGUAGE_ID,
-    HASKELL_LANGUAGE_ID,
-  ]
+  const languageIds = [CABAL_LANGUAGE_ID, HASKELL_LANGUAGE_ID];
   languageIds.forEach((languageId: string) => {
-    vscode.languages.registerDocumentFormattingEditProvider(
-      languageId,
-      {
-        provideDocumentFormattingEdits: (document, _, token) =>
-          formatDocument(languageId, channel, document, token)
-      })
+    vscode.languages.registerDocumentFormattingEditProvider(languageId, {
+      provideDocumentFormattingEdits: (document, _, token) =>
+        formatDocument(languageId, channel, document, token),
+    });
 
-    vscode.languages.registerDocumentRangeFormattingEditProvider(
-      languageId,
-      {
-        provideDocumentRangeFormattingEdits: (document, range, _, token) =>
-          formatDocumentRange(languageId, channel, document, range, token)
-      })
-  })
+    vscode.languages.registerDocumentRangeFormattingEditProvider(languageId, {
+      provideDocumentRangeFormattingEdits: (document, range, _, token) =>
+        formatDocumentRange(languageId, channel, document, range, token),
+    });
+  });
 
-  commandHaskellInterpret(channel, status, interpreterCollection)
+  commandHaskellInterpret(channel, status, interpreterCollection);
 
-  const end = perfHooks.performance.now()
-  const elapsed = ((end - start) / 1000).toFixed(3)
-  log(channel, key, `Successfully activated in ${elapsed} seconds.`)
+  const end = perfHooks.performance.now();
+  const elapsed = ((end - start) / 1000).toFixed(3);
+  log(channel, key, `Successfully activated in ${elapsed} seconds.`);
 }
 
 function commandHaskellInterpret(
@@ -156,18 +164,22 @@ function commandHaskellInterpret(
   status: vscode.LanguageStatusItem,
   collection: vscode.DiagnosticCollection
 ): void {
-  const document = vscode.window.activeTextEditor?.document
-  if (!document) { return }
+  const document = vscode.window.activeTextEditor?.document;
+  if (!document) {
+    return;
+  }
 
-  startInterpreter(channel, status, collection, document)
+  startInterpreter(channel, status, collection, document);
 }
 
 function commandHaskellLint(
   channel: vscode.OutputChannel,
   collection: vscode.DiagnosticCollection
 ): void {
-  const document = vscode.window.activeTextEditor?.document
-  if (!document || document.languageId !== HASKELL_LANGUAGE_ID) { return }
+  const document = vscode.window.activeTextEditor?.document;
+  if (!document || document.languageId !== HASKELL_LANGUAGE_ID) {
+    return;
+  }
 
   vscode.window.withProgress(
     {
@@ -177,15 +189,16 @@ function commandHaskellLint(
     },
     async (progress, token) => {
       progress.report({
-        message: vscode.workspace.asRelativePath(document.uri)
-      })
-      const diagnostics = await lintHaskell(channel, document, token)
-      collection.set(document.uri, diagnostics)
-    })
+        message: vscode.workspace.asRelativePath(document.uri),
+      });
+      const diagnostics = await lintHaskell(channel, document, token);
+      collection.set(document.uri, diagnostics);
+    }
+  );
 }
 
 function commandOutputShow(channel: vscode.OutputChannel): void {
-  channel.show(true)
+  channel.show(true);
 }
 
 function formatDocument(
@@ -194,22 +207,26 @@ function formatDocument(
   document: vscode.TextDocument,
   token: vscode.CancellationToken
 ): Promise<vscode.TextEdit[]> {
-  const range: vscode.Range = document.validateRange(new vscode.Range(
-    new vscode.Position(0, 0),
-    new vscode.Position(Infinity, Infinity)))
-  return formatDocumentRange(languageId, channel, document, range, token)
+  const range: vscode.Range = document.validateRange(
+    new vscode.Range(
+      new vscode.Position(0, 0),
+      new vscode.Position(Infinity, Infinity)
+    )
+  );
+  return formatDocumentRange(languageId, channel, document, range, token);
 }
 
 function expandTemplate(
   template: string,
   replacements: { [key: string]: string }
 ): string {
-  return template
-    .replace(/\$\{(.*?)\}/, (_, key) => {
-      const value = replacements[key]
-      if (typeof value === 'undefined') { throw `unknown variable: ${key}` }
-      return value
-    })
+  return template.replace(/\$\{(.*?)\}/, (_, key) => {
+    const value = replacements[key];
+    if (typeof value === "undefined") {
+      throw `unknown variable: ${key}`;
+    }
+    return value;
+  });
 }
 
 async function formatDocumentRange(
@@ -219,90 +236,105 @@ async function formatDocumentRange(
   range: vscode.Range,
   token: vscode.CancellationToken
 ): Promise<vscode.TextEdit[]> {
-  const key = newKey()
-  const start = perfHooks.performance.now()
-  const file = vscode.workspace.asRelativePath(document.uri)
-  log(channel, key, `Formatting ${file} using language ${languageId} ...`)
+  const key = newKey();
+  const start = perfHooks.performance.now();
+  const file = vscode.workspace.asRelativePath(document.uri);
+  log(channel, key, `Formatting ${file} using language ${languageId} ...`);
 
-  const folder = vscode.workspace.getWorkspaceFolder(document.uri)
+  const folder = vscode.workspace.getWorkspaceFolder(document.uri);
   if (!folder) {
-    log(channel, key, 'Error: Missing workspace folder!')
-    return []
+    log(channel, key, "Error: Missing workspace folder!");
+    return [];
   }
 
   const template: string | undefined = vscode.workspace
     .getConfiguration(my.name)
-    .get(`${languageId}.formatter.command`)
+    .get(`${languageId}.formatter.command`);
   if (!template) {
-    log(channel, key, 'Error: Missing formatter command!')
-    return []
+    log(channel, key, "Error: Missing formatter command!");
+    return [];
   }
 
-  const command = expandTemplate(template, { file })
-  const cwd = folder.uri.path
-  log(channel, key, `Running ${JSON.stringify(command)} in ${JSON.stringify(cwd)} ...`)
+  const command = expandTemplate(template, { file });
+  const cwd = folder.uri.path;
+  log(
+    channel,
+    key,
+    `Running ${JSON.stringify(command)} in ${JSON.stringify(cwd)} ...`
+  );
   const task: childProcess.ChildProcess = childProcess.spawn(command, {
     cwd,
     shell: true,
-  })
+  });
 
-  assert.ok(task.stderr)
-  readline.createInterface(task.stderr).on('line', (line) => {
-    log(channel, key, `[stderr] ${line}`)
-  })
+  assert.ok(task.stderr);
+  readline.createInterface(task.stderr).on("line", (line) => {
+    log(channel, key, `[stderr] ${line}`);
+  });
 
-  let output = ''
-  task.stdout?.on('data', (data) => output += data)
+  let output = "";
+  task.stdout?.on("data", (data) => (output += data));
 
   token.onCancellationRequested(() => {
-    log(channel, key, 'Cancelling ...')
-    task.kill()
-  })
+    log(channel, key, "Cancelling ...");
+    task.kill();
+  });
 
-  task.stdin?.end(document.getText(range))
+  task.stdin?.end(document.getText(range));
 
-  const code: number = await new Promise((resolve) => task.on('close', resolve))
+  const code: number = await new Promise((resolve) =>
+    task.on("close", resolve)
+  );
   if (code !== 0) {
-    log(channel, key, `Error: Formatter exited with ${code}!`)
+    log(channel, key, `Error: Formatter exited with ${code}!`);
     if (!task.killed) {
-      vscode.window.showErrorMessage(`Failed to format ${file}!`)
+      vscode.window.showErrorMessage(`Failed to format ${file}!`);
     }
-    return []
+    return [];
   }
 
-  const end = perfHooks.performance.now()
-  const elapsed = ((end - start) / 1000).toFixed(3)
-  log(channel, key, `Successfully formatted in ${elapsed} seconds.`)
-  return [new vscode.TextEdit(range, output)]
+  const end = perfHooks.performance.now();
+  const elapsed = ((end - start) / 1000).toFixed(3);
+  log(channel, key, `Successfully formatted in ${elapsed} seconds.`);
+  return [new vscode.TextEdit(range, output)];
 }
 
-function ideaSeverityToDiagnostic(severity: IdeaSeverity): vscode.DiagnosticSeverity {
+function ideaSeverityToDiagnostic(
+  severity: IdeaSeverity
+): vscode.DiagnosticSeverity {
   switch (severity) {
-    case IdeaSeverity.Ignore: return vscode.DiagnosticSeverity.Hint
-    default: return vscode.DiagnosticSeverity.Information
+    case IdeaSeverity.Ignore:
+      return vscode.DiagnosticSeverity.Hint;
+    default:
+      return vscode.DiagnosticSeverity.Information;
   }
 }
 
 function ideaToDiagnostic(idea: Idea): vscode.Diagnostic {
-  const range = ideaToRange(idea)
-  const message = ideaToMessage(idea)
-  const diagnosticSeverity = ideaSeverityToDiagnostic(idea.severity)
-  const diagnostic = new vscode.Diagnostic(range, message, diagnosticSeverity)
-  diagnostic.source = my.name
-  return diagnostic
+  const range = ideaToRange(idea);
+  const message = ideaToMessage(idea);
+  const diagnosticSeverity = ideaSeverityToDiagnostic(idea.severity);
+  const diagnostic = new vscode.Diagnostic(range, message, diagnosticSeverity);
+  diagnostic.source = my.name;
+  return diagnostic;
 }
 
 function ideaToMessage(idea: Idea): string {
-  const lines: string[] = [idea.hint]
-  if (idea.to) { lines.push(`Why not: ${idea.to}`) }
-  for (const note of idea.note) { lines.push(`Note: ${note}`) }
-  return lines.join('\n')
+  const lines: string[] = [idea.hint];
+  if (idea.to) {
+    lines.push(`Why not: ${idea.to}`);
+  }
+  for (const note of idea.note) {
+    lines.push(`Note: ${note}`);
+  }
+  return lines.join("\n");
 }
 
 function ideaToRange(idea: Idea): vscode.Range {
   return new vscode.Range(
     new vscode.Position(idea.startLine - 1, idea.startColumn - 1),
-    new vscode.Position(idea.endLine - 1, idea.endColumn - 1))
+    new vscode.Position(idea.endLine - 1, idea.endColumn - 1)
+  );
 }
 
 async function lintHaskell(
@@ -310,123 +342,137 @@ async function lintHaskell(
   document: vscode.TextDocument,
   token: vscode.CancellationToken
 ): Promise<vscode.Diagnostic[]> {
-  const key = newKey()
-  const start = perfHooks.performance.now()
-  const file = vscode.workspace.asRelativePath(document.uri)
-  log(channel, key, `Linting ${file} ...`)
+  const key = newKey();
+  const start = perfHooks.performance.now();
+  const file = vscode.workspace.asRelativePath(document.uri);
+  log(channel, key, `Linting ${file} ...`);
 
-  const folder = vscode.workspace.getWorkspaceFolder(document.uri)
+  const folder = vscode.workspace.getWorkspaceFolder(document.uri);
   if (!folder) {
-    log(channel, key, 'Error: Missing workspace folder!')
-    return []
+    log(channel, key, "Error: Missing workspace folder!");
+    return [];
   }
 
   const template: string | undefined = vscode.workspace
     .getConfiguration(my.name)
-    .get(`${HASKELL_LANGUAGE_ID}.linter.command`)
+    .get(`${HASKELL_LANGUAGE_ID}.linter.command`);
   if (!template) {
-    log(channel, key, 'Error: Missing linter command!')
-    return []
+    log(channel, key, "Error: Missing linter command!");
+    return [];
   }
 
-  const command = expandTemplate(template, { file })
-  const cwd = folder.uri.path
-  log(channel, key, `Running ${JSON.stringify(command)} in ${JSON.stringify(cwd)} ...`)
+  const command = expandTemplate(template, { file });
+  const cwd = folder.uri.path;
+  log(
+    channel,
+    key,
+    `Running ${JSON.stringify(command)} in ${JSON.stringify(cwd)} ...`
+  );
   const task: childProcess.ChildProcess = childProcess.spawn(command, {
     cwd,
     shell: true,
-  })
+  });
 
-  assert.ok(task.stderr)
-  readline.createInterface(task.stderr).on('line', (line) => {
-    log(channel, key, `[stderr] ${line}`)
-  })
+  assert.ok(task.stderr);
+  readline.createInterface(task.stderr).on("line", (line) => {
+    log(channel, key, `[stderr] ${line}`);
+  });
 
-  let output = ''
-  task.stdout?.on('data', (data) => output += data)
+  let output = "";
+  task.stdout?.on("data", (data) => (output += data));
 
   token.onCancellationRequested(() => {
-    log(channel, key, 'Cancelling ...')
-    task.kill()
-  })
+    log(channel, key, "Cancelling ...");
+    task.kill();
+  });
 
-  task.stdin?.end(document.getText())
+  task.stdin?.end(document.getText());
 
-  const code: number = await new Promise((resolve) => task.on('close', resolve))
+  const code: number = await new Promise((resolve) =>
+    task.on("close", resolve)
+  );
   if (code !== 0) {
-    log(channel, key, `Error: Linter exited with ${code}!`)
+    log(channel, key, `Error: Linter exited with ${code}!`);
     if (!task.killed) {
-      vscode.window.showErrorMessage(`Failed to lint ${file}!`)
+      vscode.window.showErrorMessage(`Failed to lint ${file}!`);
     }
-    return []
+    return [];
   }
 
-  let ideas: Idea[]
+  let ideas: Idea[];
   try {
-    ideas = JSON.parse(output)
+    ideas = JSON.parse(output);
   } catch (error) {
-    log(channel, key, `Error: ${error}`)
-    vscode.window.showErrorMessage(`Failed to lint ${file}!`)
-    return []
+    log(channel, key, `Error: ${error}`);
+    vscode.window.showErrorMessage(`Failed to lint ${file}!`);
+    return [];
   }
 
-  const end = perfHooks.performance.now()
-  const elapsed = ((end - start) / 1000).toFixed(3)
-  log(channel, key, `Successfully linted in ${elapsed} seconds.`)
-  return ideas.map(ideaToDiagnostic)
+  const end = perfHooks.performance.now();
+  const elapsed = ((end - start) / 1000).toFixed(3);
+  log(channel, key, `Successfully linted in ${elapsed} seconds.`);
+  return ideas.map(ideaToDiagnostic);
 }
 
-function log(
-  channel: vscode.OutputChannel,
-  key: Key,
-  message: string
-): void {
-  channel.appendLine(`${new Date().toISOString()} [${key}] ${message}`)
+function log(channel: vscode.OutputChannel, key: Key, message: string): void {
+  channel.appendLine(`${new Date().toISOString()} [${key}] ${message}`);
 }
 
 function messageSeverityToDiagnostic(
   severity: MessageSeverity
 ): vscode.DiagnosticSeverity {
   switch (severity) {
-    case MessageSeverity.SevError: return vscode.DiagnosticSeverity.Error
-    case MessageSeverity.SevFatal: return vscode.DiagnosticSeverity.Error
-    case MessageSeverity.SevWarning: return vscode.DiagnosticSeverity.Warning
-    default: return vscode.DiagnosticSeverity.Information
+    case MessageSeverity.SevError:
+      return vscode.DiagnosticSeverity.Error;
+    case MessageSeverity.SevFatal:
+      return vscode.DiagnosticSeverity.Error;
+    case MessageSeverity.SevWarning:
+      return vscode.DiagnosticSeverity.Warning;
+    default:
+      return vscode.DiagnosticSeverity.Information;
   }
 }
 
 function messageClassToDiagnostic(
   messageClass: string
 ): vscode.DiagnosticSeverity {
-  const severities = new Set(Object.values(MessageSeverity))
+  const severities = new Set(Object.values(MessageSeverity));
   for (const klass of messageClass.split(/ +/)) {
-    const severity = klass as MessageSeverity
+    const severity = klass as MessageSeverity;
     if (severities.has(severity)) {
-      return messageSeverityToDiagnostic(severity)
+      return messageSeverityToDiagnostic(severity);
     }
   }
-  return vscode.DiagnosticSeverity.Information
+  return vscode.DiagnosticSeverity.Information;
 }
 
 function messageSpanToRange(span: MessageSpan): vscode.Range {
   return new vscode.Range(
     new vscode.Position(span.startLine - 1, span.startCol - 1),
-    new vscode.Position(span.endLine - 1, span.endCol - 1))
+    new vscode.Position(span.endLine - 1, span.endCol - 1)
+  );
 }
 
 function messageToDiagnostic(message: Message): vscode.Diagnostic {
-  const range = messageSpanToRange(message.span || DEFAULT_MESSAGE_SPAN)
-  let severity = vscode.DiagnosticSeverity.Information
-  if (message.severity) { severity = messageSeverityToDiagnostic(message.severity) }
-  else if (message.messageClass) { severity = messageClassToDiagnostic(message.messageClass) }
-  const diagnostic = new vscode.Diagnostic(range, message.doc, severity)
-  if (message.reason) { diagnostic.code = message.reason }
-  diagnostic.source = my.name
-  return diagnostic
+  const range = messageSpanToRange(message.span || DEFAULT_MESSAGE_SPAN);
+  let severity = vscode.DiagnosticSeverity.Information;
+  if (message.severity) {
+    severity = messageSeverityToDiagnostic(message.severity);
+  } else if (message.messageClass) {
+    severity = messageClassToDiagnostic(message.messageClass);
+  }
+  const diagnostic = new vscode.Diagnostic(range, message.doc, severity);
+  if (message.reason) {
+    diagnostic.code = message.reason;
+  }
+  diagnostic.source = my.name;
+  return diagnostic;
 }
 
 function newKey(): Key {
-  return Math.floor(Math.random() * (0xffff + 1)).toString(16).padStart(4, '0')
+  return Math.floor(Math.random() * (0xffff + 1))
+    .toString(16)
+    .padStart(4, "0");
 }
 
 async function reloadInterpreter(
@@ -434,45 +480,45 @@ async function reloadInterpreter(
   status: vscode.LanguageStatusItem,
   collection: vscode.DiagnosticCollection
 ): Promise<void> {
-  const key = newKey()
-  const start = perfHooks.performance.now()
-  log(channel, key, 'Reloading interpreter ...')
+  const key = newKey();
+  const start = perfHooks.performance.now();
+  log(channel, key, "Reloading interpreter ...");
 
   if (!INTERPRETER) {
-    log(channel, key, 'Error: Missing interpreter!')
-    return
+    log(channel, key, "Error: Missing interpreter!");
+    return;
   }
 
   if (INTERPRETER.key) {
-    log(channel, key, `Ignoring because ${INTERPRETER.key} is running.`)
-    return
+    log(channel, key, `Ignoring because ${INTERPRETER.key} is running.`);
+    return;
   }
 
-  INTERPRETER.key = key
+  INTERPRETER.key = key;
 
-  status.busy = true
-  status.detail = ''
-  status.text = 'Loading'
+  status.busy = true;
+  status.detail = "";
+  status.text = "Loading";
 
-  const document = vscode.window.activeTextEditor?.document
+  const document = vscode.window.activeTextEditor?.document;
   if (document) {
-    const folder = vscode.workspace.getWorkspaceFolder(document.uri)
+    const folder = vscode.workspace.getWorkspaceFolder(document.uri);
     if (folder) {
-      collection.delete(folder.uri)
+      collection.delete(folder.uri);
     }
   }
 
-  const input = ':reload'
-  log(channel, key, `[stdin] ${input}`)
-  INTERPRETER.task.stdin?.write(`${input}\n`)
+  const input = ":reload";
+  log(channel, key, `[stdin] ${input}`);
+  INTERPRETER.task.stdin?.write(`${input}\n`);
 
   while (INTERPRETER.key === key) {
-    await new Promise((resolve) => setTimeout(resolve, 100))
+    await new Promise((resolve) => setTimeout(resolve, 100));
   }
 
-  const end = perfHooks.performance.now()
-  const elapsed = ((end - start) / 1000).toFixed(3)
-  log(channel, key, `Finished reloading in ${elapsed} seconds.`)
+  const end = perfHooks.performance.now();
+  const elapsed = ((end - start) / 1000).toFixed(3);
+  log(channel, key, `Finished reloading in ${elapsed} seconds.`);
 }
 
 async function startInterpreter(
@@ -481,152 +527,157 @@ async function startInterpreter(
   collection: vscode.DiagnosticCollection,
   document: vscode.TextDocument
 ): Promise<void> {
-  const key = newKey()
-  const start = perfHooks.performance.now()
-  log(channel, key, 'Starting interpreter ...')
+  const key = newKey();
+  const start = perfHooks.performance.now();
+  log(channel, key, "Starting interpreter ...");
 
-  const folder = vscode.workspace.getWorkspaceFolder(document.uri)
+  const folder = vscode.workspace.getWorkspaceFolder(document.uri);
   if (!folder) {
-    log(channel, key, 'Error: Missing workspace folder!')
-    return
+    log(channel, key, "Error: Missing workspace folder!");
+    return;
   }
 
   const interpreter: string | undefined = vscode.workspace
     .getConfiguration(my.name)
-    .get(`${HASKELL_LANGUAGE_ID}.interpreter.command`)
+    .get(`${HASKELL_LANGUAGE_ID}.interpreter.command`);
   let template: string | undefined = undefined;
   switch (interpreter) {
-    case 'cabal':
-      template = 'cabal repl --repl-options -ddump-json'
-      break
-    case 'stack':
-      template = 'stack ghci --ghci-options -ddump-json'
-      break
-    case 'ghci':
-      template = 'ghci -ddump-json ${file}'
-      break
-    case 'custom':
+    case "cabal":
+      template = "cabal repl --repl-options -ddump-json";
+      break;
+    case "stack":
+      template = "stack ghci --ghci-options -ddump-json";
+      break;
+    case "ghci":
+      template = "ghci -ddump-json ${file}";
+      break;
+    case "custom":
       template = vscode.workspace
         .getConfiguration(my.name)
-        .get(`${HASKELL_LANGUAGE_ID}.interpreter.custom`)
-      break
+        .get(`${HASKELL_LANGUAGE_ID}.interpreter.custom`);
+      break;
     default:
-      break
+      break;
   }
 
   if (!template) {
-    log(channel, key, 'Error: Missing interpreter command!')
-    return
+    log(channel, key, "Error: Missing interpreter command!");
+    return;
   }
 
-  const file = vscode.workspace.asRelativePath(document.uri)
-  const command = expandTemplate(template, { file })
+  const file = vscode.workspace.asRelativePath(document.uri);
+  const command = expandTemplate(template, { file });
 
-  status.busy = true
-  status.detail = ''
-  status.severity = vscode.LanguageStatusSeverity.Information
-  status.text = 'Starting'
+  status.busy = true;
+  status.detail = "";
+  status.severity = vscode.LanguageStatusSeverity.Information;
+  status.text = "Starting";
 
   if (INTERPRETER) {
-    log(channel, key, `Stopping interpreter ${INTERPRETER.task.pid} ...`)
-    INTERPRETER.task.kill()
-    INTERPRETER = null
-    collection.clear()
+    log(channel, key, `Stopping interpreter ${INTERPRETER.task.pid} ...`);
+    INTERPRETER.task.kill();
+    INTERPRETER = null;
+    collection.clear();
   }
 
-  const cwd = folder.uri.path
-  log(channel, key, `Running ${JSON.stringify(command)} in ${JSON.stringify(cwd)} ...`)
+  const cwd = folder.uri.path;
+  log(
+    channel,
+    key,
+    `Running ${JSON.stringify(command)} in ${JSON.stringify(cwd)} ...`
+  );
   const task: childProcess.ChildProcess = childProcess.spawn(command, {
     cwd,
     shell: true,
-  })
-  INTERPRETER = { key, task }
+  });
+  INTERPRETER = { key, task };
 
-  task.on('close', (code) => {
-    log(channel, key, `Error: Interpreter exited with ${code}!`)
+  task.on("close", (code) => {
+    log(channel, key, `Error: Interpreter exited with ${code}!`);
     if (code !== null) {
-      status.busy = false
-      status.detail = ''
-      status.text = 'Exited'
-      status.severity = vscode.LanguageStatusSeverity.Error
+      status.busy = false;
+      status.detail = "";
+      status.text = "Exited";
+      status.severity = vscode.LanguageStatusSeverity.Error;
     }
-  })
+  });
 
-  assert.ok(task.stderr)
-  readline.createInterface(task.stderr).on('line', (line) => {
-    log(channel, key, `[stderr] ${line}`)
-  })
+  assert.ok(task.stderr);
+  readline.createInterface(task.stderr).on("line", (line) => {
+    log(channel, key, `[stderr] ${line}`);
+  });
 
-  const prompt = `{- ${my.name} ${my.version} ${key} -}`
-  const input = `:set prompt "${prompt}\\n"`
-  log(channel, key, `[stdin] ${input}`)
-  task.stdin?.write(`${input}\n`)
+  const prompt = `{- ${my.name} ${my.version} ${key} -}`;
+  const input = `:set prompt "${prompt}\\n"`;
+  log(channel, key, `[stdin] ${input}`);
+  task.stdin?.write(`${input}\n`);
 
   await new Promise<void>((resolve) => {
-    assert.ok(task.stdout)
-    readline.createInterface(task.stdout).on('line', (line) => {
-      let shouldLog: boolean = true
+    assert.ok(task.stdout);
+    readline.createInterface(task.stdout).on("line", (line) => {
+      let shouldLog: boolean = true;
 
       if (line.includes(prompt)) {
-        if (INTERPRETER?.key) { INTERPRETER.key = null }
-        resolve()
-        status.busy = false
-        status.detail = ''
-        status.text = 'Idle'
-        shouldLog = false
+        if (INTERPRETER?.key) {
+          INTERPRETER.key = null;
+        }
+        resolve();
+        status.busy = false;
+        status.detail = "";
+        status.text = "Idle";
+        shouldLog = false;
       }
 
-      let message: Message | null = null
+      let message: Message | null = null;
       try {
-        message = JSON.parse(line)
-      }
-      catch (error) {
+        message = JSON.parse(line);
+      } catch (error) {
         if (!(error instanceof SyntaxError)) {
-          throw error
+          throw error;
         }
       }
 
       if (message) {
-        const pattern = /^\[ *(\d+) of (\d+)\] Compiling ([^ ]+) +\( ([^,]+)/
-        const match = message.doc.match(pattern)
+        const pattern = /^\[ *(\d+) of (\d+)\] Compiling ([^ ]+) +\( ([^,]+)/;
+        const match = message.doc.match(pattern);
         if (match) {
-          status.detail = `${match[1]} of ${match[2]}: ${match[3]}`
+          status.detail = `${match[1]} of ${match[2]}: ${match[3]}`;
 
-          assert.ok(match[4])
-          const uri = vscode.Uri.joinPath(folder.uri, match[4])
-          collection.delete(uri)
+          assert.ok(match[4]);
+          const uri = vscode.Uri.joinPath(folder.uri, match[4]);
+          collection.delete(uri);
 
-          shouldLog = false
+          shouldLog = false;
         } else {
-          let uri: vscode.Uri | null = null
+          let uri: vscode.Uri | null = null;
           if (message.span) {
             if (message.span.file !== DEFAULT_MESSAGE_SPAN.file) {
               if (path.isAbsolute(message.span.file)) {
-                uri = vscode.Uri.file(message.span.file)
+                uri = vscode.Uri.file(message.span.file);
               } else {
-                uri = vscode.Uri.joinPath(folder.uri, message.span.file)
+                uri = vscode.Uri.joinPath(folder.uri, message.span.file);
               }
             }
           } else {
-            uri = folder.uri
+            uri = folder.uri;
           }
 
           if (uri) {
-            const diagnostic = messageToDiagnostic(message)
-            collection.set(uri, (collection.get(uri) || []).concat(diagnostic))
+            const diagnostic = messageToDiagnostic(message);
+            collection.set(uri, (collection.get(uri) || []).concat(diagnostic));
 
-            shouldLog = false
+            shouldLog = false;
           }
         }
       }
 
       if (shouldLog) {
-        log(channel, INTERPRETER?.key || '0000', `[stdout] ${line}`)
+        log(channel, INTERPRETER?.key || "0000", `[stdout] ${line}`);
       }
-    })
-  })
+    });
+  });
 
-  const end = perfHooks.performance.now()
-  const elapsed = ((end - start) / 1000).toFixed(3)
-  log(channel, key, `Successfully started in ${elapsed} seconds.`)
+  const end = perfHooks.performance.now();
+  const elapsed = ((end - start) / 1000).toFixed(3);
+  log(channel, key, `Successfully started in ${elapsed} seconds.`);
 }

--- a/source/client.ts
+++ b/source/client.ts
@@ -130,7 +130,7 @@ async function setInterpreterTemplate(
   let mode: string | undefined = vscode.workspace
     .getConfiguration(my.name)
     .get(`${HASKELL_LANGUAGE_ID}.interpreter.mode`);
-  log(channel, key, `Selected mode is: ${JSON.stringify(mode)}`);
+  log(channel, key, `Requested Haskell interpreter mode is ${mode}`);
 
   if (mode === INTERPRETER_MODE_DISCOVER) {
     const cabal = await which("cabal", { nothrow: true });
@@ -170,7 +170,7 @@ async function setInterpreterTemplate(
       mode = INTERPRETER_MODE_GHCI;
     }
   }
-  log(channel, key, `Actual mode is: ${JSON.stringify(mode)}`);
+  log(channel, key, `Actual Haskell interpreter mode is ${mode}`);
 
   switch (mode) {
     case INTERPRETER_MODE_CABAL:
@@ -191,7 +191,6 @@ async function setInterpreterTemplate(
       INTERPRETER_TEMPLATE = undefined;
       break;
   }
-  log(channel, key, `Template is: ${JSON.stringify(INTERPRETER_TEMPLATE)}`);
 }
 
 async function setHaskellFormatterTemplate(
@@ -203,7 +202,7 @@ async function setHaskellFormatterTemplate(
   let mode: string | undefined = vscode.workspace
     .getConfiguration(my.name)
     .get(`${HASKELL_LANGUAGE_ID}.formatter.mode`);
-  log(channel, key, `Selected mode is: ${JSON.stringify(mode)}`);
+  log(channel, key, `Requested Haskell formatter mode is ${mode}`);
 
   if (mode === HASKELL_FORMATTER_MODE_DISCOVER) {
     const ormolu = await which("ormolu", { nothrow: true });
@@ -211,7 +210,7 @@ async function setHaskellFormatterTemplate(
       mode = HASKELL_FORMATTER_MODE_ORMOLU;
     }
   }
-  log(channel, key, `Actual mode is: ${JSON.stringify(mode)}`);
+  log(channel, key, `Actual Haskell formatter mode is ${mode}`);
 
   switch (mode) {
     case HASKELL_FORMATTER_MODE_ORMOLU:
@@ -226,11 +225,6 @@ async function setHaskellFormatterTemplate(
       HASKELL_FORMATTER_TEMPLATE = undefined;
       break;
   }
-  log(
-    channel,
-    key,
-    `Template is: ${JSON.stringify(HASKELL_FORMATTER_TEMPLATE)}`
-  );
 }
 
 async function setHaskellLinterTemplate(
@@ -242,7 +236,7 @@ async function setHaskellLinterTemplate(
   let mode: string | undefined = vscode.workspace
     .getConfiguration(my.name)
     .get(`${HASKELL_LANGUAGE_ID}.linter.mode`);
-  log(channel, key, `Selected mode is: ${JSON.stringify(mode)}`);
+  log(channel, key, `Requested Haskell linter mode is ${mode}`);
 
   if (mode === HASKELL_LINTER_MODE_DISCOVER) {
     const hlint = await which("hlint", { nothrow: true });
@@ -250,7 +244,7 @@ async function setHaskellLinterTemplate(
       mode = HASKELL_LINTER_MODE_HLINT;
     }
   }
-  log(channel, key, `Actual mode is: ${JSON.stringify(mode)}`);
+  log(channel, key, `Actual Haskell linter mode is ${mode}`);
 
   switch (mode) {
     case HASKELL_LINTER_MODE_HLINT:
@@ -265,7 +259,6 @@ async function setHaskellLinterTemplate(
       HASKELL_LINTER_TEMPLATE = undefined;
       break;
   }
-  log(channel, key, `Template is: ${JSON.stringify(HASKELL_LINTER_TEMPLATE)}`);
 }
 
 async function setCabalFormatterTemplate(
@@ -277,7 +270,7 @@ async function setCabalFormatterTemplate(
   let mode: string | undefined = vscode.workspace
     .getConfiguration(my.name)
     .get(`${CABAL_LANGUAGE_ID}.formatter.mode`);
-  log(channel, key, `Selected mode is: ${JSON.stringify(mode)}`);
+  log(channel, key, `Requested Cabal formatter is ${mode}`);
 
   if (mode === CABAL_FORMATTER_MODE_DISCOVER) {
     const cabalFmt = await which("cabal-fmt", { nothrow: true });
@@ -285,7 +278,7 @@ async function setCabalFormatterTemplate(
       mode = CABAL_FORMATTER_MODE_CABAL_FMT;
     }
   }
-  log(channel, key, `Actual mode is: ${JSON.stringify(mode)}`);
+  log(channel, key, `Actual Cabal formatter is ${mode}`);
 
   switch (mode) {
     case CABAL_FORMATTER_MODE_CABAL_FMT:
@@ -300,7 +293,6 @@ async function setCabalFormatterTemplate(
       CABAL_FORMATTER_TEMPLATE = undefined;
       break;
   }
-  log(channel, key, `Template is: ${JSON.stringify(CABAL_FORMATTER_TEMPLATE)}`);
 }
 
 export async function activate(

--- a/source/client.ts
+++ b/source/client.ts
@@ -118,14 +118,23 @@ async function setHaskellFormatterTemplate(
   log(channel, key, `Requested mode is ${mode}`);
 
   if (mode === HaskellFormatterMode.Discover) {
-    const ormolu = await which("ormolu", { nothrow: true });
+    const [fourmolu, ormolu] = await Promise.all([
+      which("fourmolu", { nothrow: true }),
+      which("ormolu", { nothrow: true }),
+    ]);
+
     if (ormolu) {
       mode = HaskellFormatterMode.Ormolu;
+    } else if (fourmolu) {
+      mode = HaskellFormatterMode.Fourmolu;
     }
   }
   log(channel, key, `Actual mode is ${mode}`);
 
   switch (mode) {
+    case HaskellFormatterMode.Fourmolu:
+      HASKELL_FORMATTER_TEMPLATE = "fourmolu --stdin-input-file ${file}";
+      break;
     case HaskellFormatterMode.Ormolu:
       HASKELL_FORMATTER_TEMPLATE = "ormolu --stdin-input-file ${file}";
       break;

--- a/source/client.ts
+++ b/source/client.ts
@@ -548,7 +548,7 @@ async function startInterpreter(
 
   let interpreter: string | undefined = vscode.workspace
     .getConfiguration(my.name)
-    .get(`${HASKELL_LANGUAGE_ID}.interpreter.command`);
+    .get(`${HASKELL_LANGUAGE_ID}.interpreter.mode`);
   if (interpreter === INTERPRETER_DISCOVER) {
     const cabal = await which("cabal", { nothrow: true });
     const [cabalProject] = await vscode.workspace.findFiles(
@@ -601,7 +601,7 @@ async function startInterpreter(
     case "custom":
       template = vscode.workspace
         .getConfiguration(my.name)
-        .get(`${HASKELL_LANGUAGE_ID}.interpreter.custom`);
+        .get(`${HASKELL_LANGUAGE_ID}.interpreter.command`);
       break;
     default:
       break;

--- a/source/client.ts
+++ b/source/client.ts
@@ -6,6 +6,7 @@ import readline from "readline";
 import vscode from "vscode";
 import which from "which";
 
+import HaskellFormatterMode from "./type/HaskellFormatterMode";
 import Idea from "./type/Idea";
 import IdeaSeverity from "./type/IdeaSeverity";
 import Interpreter from "./type/Interpreter";
@@ -25,12 +26,6 @@ const DEFAULT_MESSAGE_SPAN: MessageSpan = {
   startCol: 1,
   startLine: 1,
 };
-
-const HASKELL_FORMATTER_MODE_DISCOVER = "discover";
-
-const HASKELL_FORMATTER_MODE_ORMOLU = "ormolu";
-
-const HASKELL_FORMATTER_MODE_CUSTOM = "custom";
 
 const HASKELL_LINTER_MODE_DISCOVER = "discover";
 
@@ -126,24 +121,24 @@ async function setHaskellFormatterTemplate(
   const key = newKey();
   log(channel, key, "Getting Haskell formatter ...");
 
-  let mode: string | undefined = vscode.workspace
+  let mode: HaskellFormatterMode | undefined = vscode.workspace
     .getConfiguration(my.name)
     .get(`${LanguageId.Haskell}.formatter.mode`);
   log(channel, key, `Requested mode is ${mode}`);
 
-  if (mode === HASKELL_FORMATTER_MODE_DISCOVER) {
+  if (mode === HaskellFormatterMode.Discover) {
     const ormolu = await which("ormolu", { nothrow: true });
     if (ormolu) {
-      mode = HASKELL_FORMATTER_MODE_ORMOLU;
+      mode = HaskellFormatterMode.Ormolu;
     }
   }
   log(channel, key, `Actual mode is ${mode}`);
 
   switch (mode) {
-    case HASKELL_FORMATTER_MODE_ORMOLU:
+    case HaskellFormatterMode.Ormolu:
       HASKELL_FORMATTER_TEMPLATE = "ormolu --stdin-input-file ${file}";
       break;
-    case HASKELL_FORMATTER_MODE_CUSTOM:
+    case HaskellFormatterMode.Custom:
       HASKELL_FORMATTER_TEMPLATE = vscode.workspace
         .getConfiguration(my.name)
         .get(`${LanguageId.Haskell}.formatter.command`);

--- a/source/client.ts
+++ b/source/client.ts
@@ -18,6 +18,7 @@ import LanguageId from "./type/LanguageId";
 import Message from "./type/Message";
 import MessageSeverity from "./type/MessageSeverity";
 import MessageSpan from "./type/MessageSpan";
+import Template from "./type/Template";
 
 import my from "../package.json";
 
@@ -31,13 +32,13 @@ const DEFAULT_MESSAGE_SPAN: MessageSpan = {
 
 let INTERPRETER: Interpreter | null = null;
 
-let INTERPRETER_TEMPLATE: string | undefined = undefined;
+let INTERPRETER_TEMPLATE: Template | undefined = undefined;
 
-let HASKELL_FORMATTER_TEMPLATE: string | undefined = undefined;
+let HASKELL_FORMATTER_TEMPLATE: Template | undefined = undefined;
 
-let HASKELL_LINTER_TEMPLATE: string | undefined = undefined;
+let HASKELL_LINTER_TEMPLATE: Template | undefined = undefined;
 
-let CABAL_FORMATTER_TEMPLATE: string | undefined = undefined;
+let CABAL_FORMATTER_TEMPLATE: Template | undefined = undefined;
 
 async function setInterpreterTemplate(
   channel: vscode.OutputChannel
@@ -382,7 +383,7 @@ function formatDocument(
 }
 
 function expandTemplate(
-  template: string,
+  template: Template,
   replacements: { [key: string]: string }
 ): string {
   return template.replace(/\$\{(.*?)\}/, (_, key) => {
@@ -412,7 +413,7 @@ async function formatDocumentRange(
     return [];
   }
 
-  let template: string | undefined = undefined;
+  let template: Template | undefined = undefined;
   if (languageId === LanguageId.Haskell) {
     template = HASKELL_FORMATTER_TEMPLATE;
   } else if (languageId === LanguageId.Cabal) {

--- a/source/client.ts
+++ b/source/client.ts
@@ -6,70 +6,15 @@ import readline from "readline";
 import vscode from "vscode";
 import which from "which";
 
+import Idea from "./type/Idea";
+import IdeaSeverity from "./type/IdeaSeverity";
+import Interpreter from "./type/Interpreter";
+import Key from "./type/Key";
+import Message from "./type/Message";
+import MessageSeverity from "./type/MessageSeverity";
+import MessageSpan from "./type/MessageSpan";
+
 import my from "../package.json";
-
-// https://hackage.haskell.org/package/hlint-3.6.1/docs/Language-Haskell-HLint.html#t:Idea
-interface Idea {
-  decl: string[];
-  endColumn: number;
-  endLine: number;
-  file: string;
-  from: string;
-  hint: string;
-  module: string[];
-  note: string[];
-  refactorings: string;
-  severity: IdeaSeverity;
-  startColumn: number;
-  startLine: number;
-  to: string | null;
-}
-
-// https://hackage.haskell.org/package/hlint-3.6.1/docs/Language-Haskell-HLint.html#t:Severity
-enum IdeaSeverity {
-  Ignore = "Ignore",
-  Suggestion = "Suggestion",
-  Warning = "Warning",
-  Error = "Error",
-}
-
-interface Interpreter {
-  key: Key | null;
-  task: childProcess.ChildProcess;
-}
-
-type Key = string;
-
-interface Message {
-  doc: string;
-  messageClass: string | null; // Used by GHC >= 9.4.
-  reason: MessageReason | null;
-  severity: MessageSeverity | null; // Used by GHC < 9.4.
-  span: MessageSpan | null;
-}
-
-// https://downloads.haskell.org/ghc/9.6.2/docs/libraries/ghc-9.6.2/GHC-Driver-Flags.html#t:WarningFlag
-type MessageReason = string;
-
-// https://downloads.haskell.org/ghc/9.6.2/docs/libraries/ghc-9.6.2/GHC-Types-Error.html#t:Severity
-enum MessageSeverity {
-  SevDump = "SevDump",
-  SevError = "SevError",
-  SevFatal = "SevFatal",
-  SevInfo = "SevInfo",
-  SevInteractive = "SevInteractive",
-  SevOutput = "SevOutput",
-  SevWarning = "SevWarning",
-}
-
-// https://downloads.haskell.org/ghc/9.6.2/docs/libraries/ghc-9.6.2/GHC-Types-SrcLoc.html#t:SrcSpan
-interface MessageSpan {
-  endCol: number;
-  endLine: number;
-  file: string; // Can be `"<interactive>"`.
-  startCol: number;
-  startLine: number;
-}
 
 const DEFAULT_MESSAGE_SPAN: MessageSpan = {
   endCol: 1,

--- a/source/type/CabalFormatterMode.ts
+++ b/source/type/CabalFormatterMode.ts
@@ -1,0 +1,7 @@
+enum CabalFormatterMode {
+  Discover = "discover",
+  CabalFmt = "cabal-fmt",
+  Custom = "custom",
+}
+
+export default CabalFormatterMode;

--- a/source/type/HaskellFormatterMode.ts
+++ b/source/type/HaskellFormatterMode.ts
@@ -1,5 +1,6 @@
 enum HaskellFormatterMode {
   Discover = "discover",
+  Fourmolu = "fourmolu",
   Ormolu = "ormolu",
   Custom = "custom",
 }

--- a/source/type/HaskellFormatterMode.ts
+++ b/source/type/HaskellFormatterMode.ts
@@ -1,0 +1,7 @@
+enum HaskellFormatterMode {
+  Discover = "discover",
+  Ormolu = "ormolu",
+  Custom = "custom",
+}
+
+export default HaskellFormatterMode;

--- a/source/type/HaskellLinterMode.ts
+++ b/source/type/HaskellLinterMode.ts
@@ -1,0 +1,7 @@
+enum HaskellLinterMode {
+  Discover = "discover",
+  Hlint = "hlint",
+  Custom = "custom",
+}
+
+export default HaskellLinterMode;

--- a/source/type/Idea.ts
+++ b/source/type/Idea.ts
@@ -1,0 +1,20 @@
+import IdeaSeverity from "./IdeaSeverity";
+
+// https://hackage.haskell.org/package/hlint-3.6.1/docs/Language-Haskell-HLint.html#t:Idea
+interface Idea {
+  decl: string[];
+  endColumn: number;
+  endLine: number;
+  file: string;
+  from: string;
+  hint: string;
+  module: string[];
+  note: string[];
+  refactorings: string;
+  severity: IdeaSeverity;
+  startColumn: number;
+  startLine: number;
+  to: string | null;
+}
+
+export default Idea;

--- a/source/type/IdeaSeverity.ts
+++ b/source/type/IdeaSeverity.ts
@@ -1,0 +1,9 @@
+// https://hackage.haskell.org/package/hlint-3.6.1/docs/Language-Haskell-HLint.html#t:Severity
+enum IdeaSeverity {
+  Ignore = "Ignore",
+  Suggestion = "Suggestion",
+  Warning = "Warning",
+  Error = "Error",
+}
+
+export default IdeaSeverity;

--- a/source/type/Interpreter.ts
+++ b/source/type/Interpreter.ts
@@ -1,0 +1,10 @@
+import childProcess from "child_process";
+
+import Key from "./Key";
+
+interface Interpreter {
+  key: Key | null;
+  task: childProcess.ChildProcess;
+}
+
+export default Interpreter;

--- a/source/type/InterpreterMode.ts
+++ b/source/type/InterpreterMode.ts
@@ -1,0 +1,9 @@
+enum InterpreterMode {
+  Discover = "discover",
+  Cabal = "cabal",
+  Stack = "stack",
+  Ghci = "ghci",
+  Custom = "custom",
+}
+
+export default InterpreterMode;

--- a/source/type/Key.ts
+++ b/source/type/Key.ts
@@ -1,0 +1,3 @@
+type Key = string;
+
+export default Key;

--- a/source/type/LanguageId.ts
+++ b/source/type/LanguageId.ts
@@ -1,0 +1,6 @@
+enum LanguageId {
+  Cabal = "cabal",
+  Haskell = "haskell",
+}
+
+export default LanguageId;

--- a/source/type/Message.ts
+++ b/source/type/Message.ts
@@ -1,0 +1,13 @@
+import MessageReason from "./MessageReason";
+import MessageSeverity from "./MessageSeverity";
+import MessageSpan from "./MessageSpan";
+
+interface Message {
+  doc: string;
+  messageClass: string | null; // Used by GHC >= 9.4.
+  reason: MessageReason | null;
+  severity: MessageSeverity | null; // Used by GHC < 9.4.
+  span: MessageSpan | null;
+}
+
+export default Message;

--- a/source/type/MessageReason.ts
+++ b/source/type/MessageReason.ts
@@ -1,0 +1,4 @@
+// https://downloads.haskell.org/ghc/9.6.2/docs/libraries/ghc-9.6.2/GHC-Driver-Flags.html#t:WarningFlag
+type MessageReason = string;
+
+export default MessageReason;

--- a/source/type/MessageSeverity.ts
+++ b/source/type/MessageSeverity.ts
@@ -1,0 +1,12 @@
+// https://downloads.haskell.org/ghc/9.6.2/docs/libraries/ghc-9.6.2/GHC-Types-Error.html#t:Severity
+enum MessageSeverity {
+  SevDump = "SevDump",
+  SevError = "SevError",
+  SevFatal = "SevFatal",
+  SevInfo = "SevInfo",
+  SevInteractive = "SevInteractive",
+  SevOutput = "SevOutput",
+  SevWarning = "SevWarning",
+}
+
+export default MessageSeverity;

--- a/source/type/MessageSpan.ts
+++ b/source/type/MessageSpan.ts
@@ -1,0 +1,10 @@
+// https://downloads.haskell.org/ghc/9.6.2/docs/libraries/ghc-9.6.2/GHC-Types-SrcLoc.html#t:SrcSpan
+interface MessageSpan {
+  endCol: number;
+  endLine: number;
+  file: string; // Can be `"<interactive>"`.
+  startCol: number;
+  startLine: number;
+}
+
+export default MessageSpan;

--- a/source/type/Template.ts
+++ b/source/type/Template.ts
@@ -1,0 +1,3 @@
+type Template = string;
+
+export default Template;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,8 @@
     "outDir": "dist",
     "resolveJsonModule": true
   },
-  "extends": "@tsconfig/node16-strictest/tsconfig.json"
+  "extends": [
+    "@tsconfig/node16/tsconfig.json",
+    "@tsconfig/strictest/tsconfig.json"
+  ]
 }


### PR DESCRIPTION
The goal here is to make Purple Yolk easier to use by simplifying the config. Currently you have to know what you're doing in order to use PY. It would be nice if things were more automatic. For example, PY could automatically choose Cabal or Stack based on either your project config (`cabal.project` or `stack.yaml`) or the tools available on your system (`cabal` or `stack`). And similar things go for formatting and linting. 

I'm opening this as a draft because I still have plenty of work to do. 