### PR TITLE
Improve formatter config

### DIFF
--- a/source/client.ts
+++ b/source/client.ts
@@ -244,6 +244,16 @@ async function setHaskellLinterTemplate(
   }
 }
 
+function discoverCabalFormatterMode(
+  cabalFmt: string | undefined
+): CabalFormatterMode {
+  if (cabalFmt) {
+    return CabalFormatterMode.CabalFmt;
+  }
+
+  return CabalFormatterMode.Discover;
+}
+
 async function setCabalFormatterTemplate(
   channel: vscode.OutputChannel
 ): Promise<void> {
@@ -257,9 +267,8 @@ async function setCabalFormatterTemplate(
 
   if (mode === CabalFormatterMode.Discover) {
     const cabalFmt = await which("cabal-fmt", { nothrow: true });
-    if (cabalFmt) {
-      mode = CabalFormatterMode.CabalFmt;
-    }
+
+    mode = discoverCabalFormatterMode(cabalFmt);
   }
   log(channel, key, `Actual mode is ${mode}`);
 

--- a/source/client.ts
+++ b/source/client.ts
@@ -201,6 +201,16 @@ async function setHaskellFormatterTemplate(
   }
 }
 
+function discoverHaskellLinterMode(
+  hlint: string | undefined
+): HaskellLinterMode {
+  if (hlint) {
+    return HaskellLinterMode.Hlint;
+  }
+
+  return HaskellLinterMode.Discover;
+}
+
 async function setHaskellLinterTemplate(
   channel: vscode.OutputChannel
 ): Promise<void> {
@@ -214,9 +224,8 @@ async function setHaskellLinterTemplate(
 
   if (mode === HaskellLinterMode.Discover) {
     const hlint = await which("hlint", { nothrow: true });
-    if (hlint) {
-      mode = HaskellLinterMode.Hlint;
-    }
+
+    mode = discoverHaskellLinterMode(hlint);
   }
   log(channel, key, `Actual mode is ${mode}`);
 


### PR DESCRIPTION
The only functional change here is how the Haskell formatter is selected when the mode is "discover". Previously it would prefer Ormolu to Fourmolu. Now it will look for their corresponding config files (`.ormolu` and `fourmolu.yaml`) and select the appropriate formatter based on that. This is similar to how the interpreter is selected. 