### PR TITLE
Enable HLint by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
           "type": "string"
         },
         "purple-yolk.haskell.linter.onSave": {
-          "default": false,
+          "default": true,
           "description": "Should the linter be run automatically on save?",
           "type": "boolean"
         }


### PR DESCRIPTION
If `hlint` isn't installed, that should be fine since the discovery process will return `undefined` and Purple Yolk won't attempt to run anything. That's the only reason I had this disabled by default before — it used to attempt to run `hlint` even if it didn't exist. 