### PR TITLE
Improve diagnostic collections

### DIFF
--- a/source/client.ts
+++ b/source/client.ts
@@ -610,6 +610,8 @@ function commandHaskellLint(
     return;
   }
 
+  collection.delete(document.uri);
+
   vscode.window.withProgress(
     {
       cancellable: true,

--- a/source/client.ts
+++ b/source/client.ts
@@ -481,10 +481,8 @@ export async function activate(
   const start = perfHooks.performance.now();
   log(channel, key, `Activating ${my.name} version ${my.version} ...`);
 
-  const interpreterCollection = vscode.languages.createDiagnosticCollection(
-    my.name
-  );
-  const linterCollection = vscode.languages.createDiagnosticCollection(my.name);
+  const interpreterCollection = vscode.languages.createDiagnosticCollection("ghc");
+  const linterCollection = vscode.languages.createDiagnosticCollection("hlint");
 
   const status = vscode.languages.createLanguageStatusItem(
     my.name,


### PR DESCRIPTION
Two small things here:

- Both the interpreter and linter diagnostic collections used to be called `purple-yolk`. Now they're `ghc` and `hlint` respectively.
- When interpreting, we clear diagnostics as files are processed. We weren't doing that for linting. Now we are. In other words, stale linting diagnostics should go away. 