### PR TITLE
Make activation more robust

### DIFF
--- a/source/client.ts
+++ b/source/client.ts
@@ -476,6 +476,8 @@ function updateStatus(
 export async function activate(
   context: vscode.ExtensionContext
 ): Promise<void> {
+  const document = vscode.window.activeTextEditor?.document;
+
   const channel = vscode.window.createOutputChannel(my.displayName);
   const key = newKey();
   const start = perfHooks.performance.now();
@@ -581,7 +583,15 @@ export async function activate(
     await Promise.all(promises);
   });
 
-  commandHaskellInterpret(channel, status, interpreterCollection);
+  if (document) {
+    // If the user had a document open when the extension was activated, then
+    // it can be used for starting the interpreter.
+    startInterpreter(channel, status, interpreterCollection, document);
+  } else {
+    // Otherwise the interpreter command can be run, which will determine the
+    // current active document (if there is one).
+    commandHaskellInterpret(channel, status, interpreterCollection);
+  }
 
   const end = perfHooks.performance.now();
   const elapsed = ((end - start) / 1000).toFixed(3);


### PR DESCRIPTION
It's possible to get into a bad state where the interpreter doesn't actually start. Here's how:

- Open a new VSCode window.
- Open a Haskell file, then quickly close it. 
- Open another Haskell file (or the same one again). Purple Yolk's interpreter probably won't be running. 

This happens because when Purple Yolk activates, it takes a non-zero amount of time to discover all the relevant configuration. If you don't have any files open when that finishes, then Purple Yolk won't know where your workspace lives. That means it won't be able to start an interpreter, because that requires an active text editor. 

This feels a little hokey for Cabal and Stack since they really only need a _folder_ to start up. But for GHCi, it really can't be started without an actual file, which means an active text editor. 