### PR TITLE
Start interpreter if it's missing

### DIFF
--- a/source/client.ts
+++ b/source/client.ts
@@ -964,6 +964,10 @@ async function reloadInterpreter(
   const start = perfHooks.performance.now();
   log(channel, key, "Reloading interpreter ...");
 
+  const document = vscode.window.activeTextEditor?.document;
+  if (!INTERPRETER && document) {
+    await startInterpreter(channel, status, collection, document);
+  }
   if (!INTERPRETER) {
     log(channel, key, "Error: Missing interpreter!");
     return;
@@ -978,7 +982,6 @@ async function reloadInterpreter(
 
   updateStatus(status, true, vscode.LanguageStatusSeverity.Information, "Loading");
 
-  const document = vscode.window.activeTextEditor?.document;
   if (document) {
     const folder = vscode.workspace.getWorkspaceFolder(document.uri);
     if (folder) {

--- a/source/client.ts
+++ b/source/client.ts
@@ -1026,14 +1026,14 @@ async function startInterpreter(
   const file = vscode.workspace.asRelativePath(document.uri);
   const command = expandTemplate(INTERPRETER_TEMPLATE, { file });
 
-  updateStatus(status, true, vscode.LanguageStatusSeverity.Information, "Starting");
-
   if (INTERPRETER) {
     log(channel, key, `Stopping interpreter ${INTERPRETER.task.pid} ...`);
     INTERPRETER.task.kill();
     INTERPRETER = null;
     collection.clear();
   }
+
+  updateStatus(status, true, vscode.LanguageStatusSeverity.Information, "Starting");
 
   const cwd = folder.uri.path;
   log(


### PR DESCRIPTION
This follows on from #71. Instead of making activation more robust, it simply tries to start the interpreter if it's not already running. 