### PR TITLE
Make Purple Yolk work on Windows

### DIFF
--- a/source/client.ts
+++ b/source/client.ts
@@ -714,7 +714,7 @@ async function formatDocumentRange(
   }
 
   const command = expandTemplate(template, { file });
-  const cwd = rootUri.path;
+  const cwd = rootUri.fsPath;
   log(
     channel,
     key,
@@ -813,7 +813,7 @@ async function lintHaskell(
   }
 
   const command = expandTemplate(HASKELL_LINTER_TEMPLATE, { file });
-  const cwd = rootUri.path;
+  const cwd = rootUri.fsPath;
   log(
     channel,
     key,
@@ -1054,7 +1054,7 @@ async function startInterpreter(
 
   updateStatus(status, true, vscode.LanguageStatusSeverity.Information, "Starting");
 
-  const cwd = rootUri.path;
+  const cwd = rootUri.fsPath;
   log(
     channel,
     key,


### PR DESCRIPTION
Correct path format in `cwd` argument

Use [Uri.fsPath](https://code.visualstudio.com/api/references/vscode-api#Uri.fsPath) (instead of `path`) which returns URI file path in platform-specific format.

This version should work on all threee supported platforms: Linux, MacOS & Windows

Fixes: #85