### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -41,6 +41,104 @@
           "run": "npx vsce publish --packagePath purple-yolk.vsix --pat \"${{ secrets.AZURE_PERSONAL_ACCESS_TOKEN }}\""
         }
       ]
+    },
+    "matrix-build": {
+      "strategy": {
+        "fail-fast": false,
+        "matrix": {
+          "os": [
+            "ubuntu-latest",
+            "windows-latest",
+            "macos-latest"
+          ],
+          "ghc": [
+            "8.10.7",
+            "9.0.2",
+            "9.6.5"
+          ],
+          "env": [
+            {
+              "CODE_VERSION": "stable",
+              "DISPLAY": ":99.0"
+            }
+          ]
+        }
+      },
+      "runs-on": "${{ matrix.os }}",
+      "env": "${{ matrix.env }}",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Set up npm",
+          "uses": "actions/setup-node@v4",
+          "with": {
+            "node-version": 18
+          }
+        },
+        {
+          "name": "Install Haskell Stack",
+          "if": "runner.os == 'macOS'",
+          "run": "brew install llvm@12\necho \"/opt/homebrew/opt/llvm@12/bin\" >> $GITHUB_PATH\nbrew install haskell-stack\n"
+        },
+        {
+          "name": "Set up GHC ${{ matrix.ghc }} environment",
+          "run": "echo \"resolver: ghc-${{ matrix.ghc }}\" > stack.yaml\necho \"packages: []\" >> stack.yaml\nstack setup\n"
+        },
+        {
+          "run": "npm install"
+        },
+        {
+          "name": "Run npm test",
+          "uses": "coactions/setup-xvfb@v1",
+          "with": {
+            "run": "npm test"
+          }
+        }
+      ]
+    },
+    "metrics": {
+      "runs-on": "ubuntu-latest",
+      "env": {
+        "CODE_VERSION": "stable",
+        "DISPLAY": ":99.0",
+        "GHC": "9.6.5"
+      },
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Set up npm",
+          "uses": "actions/setup-node@v4",
+          "with": {
+            "node-version": 18
+          }
+        },
+        {
+          "name": "Set up GHC ${{ env.GHC }} environment",
+          "run": "echo \"resolver: ghc-${{ env.GHC }}\" > stack.yaml\necho \"packages: []\" >> stack.yaml\nstack setup\n"
+        },
+        {
+          "run": "npm install"
+        },
+        {
+          "name": "Run tests with coverage",
+          "uses": "coactions/setup-xvfb@v1",
+          "with": {
+            "run": "npm run coverage"
+          }
+        },
+        {
+          "name": "Publish coverage on Coveralls.io",
+          "uses": "coverallsapp/github-action@v2",
+          "with": {
+            "github-token": "${{ secrets.GITHUB_TOKEN }}",
+            "path-to-lcov": ".coverage/lcov.info"
+          }
+        }
+      ]
     }
   },
   "name": "Workflow",

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # https://git-scm.com/docs/gitignore
-/.vscode/
+/.coverage
+/.vscode-test
 /dist/
 /node_modules/
 /package-lock.json

--- a/data/test/Error.hs
+++ b/data/test/Error.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+main :: IO ()
+main =
+    print "Nope"

--- a/data/test/OK.hs
+++ b/data/test/OK.hs
@@ -1,0 +1,4 @@
+
+main :: IO ()
+main =
+    print "OK"

--- a/data/test/Warning.hs
+++ b/data/test/Warning.hs
@@ -1,0 +1,3 @@
+
+main =
+    print "OK"

--- a/package.json
+++ b/package.json
@@ -209,11 +209,19 @@
   "devDependencies": {
     "@tsconfig/node18": "^18.2.4",
     "@tsconfig/strictest": "^2.0.5",
+    "@types/chai": "4.3.16",
+    "@types/glob": "^8.1.0",
+    "@types/mocha": "10.0.6",
     "@types/node": "^20.12.8",
     "@types/vscode": "^1.89.0",
     "@types/which": "^3.0.3",
+    "@vscode/test-electron": "2.3.9",
     "@vscode/vsce": "^2.26.1",
+    "c8": "^10.1.2",
+    "chai": "4.4.1",
     "esbuild": "^0.23.0",
+    "mocha": "10.4.0",
+    "ts-node": "10.9.2",
     "typescript": "^5.4.5",
     "vscode-uri": "^3.0.8",
     "which": "^4.0.0"
@@ -237,7 +245,31 @@
     "url": "https://github.com/tfausak/purple-yolk.git"
   },
   "scripts": {
+    "precompile": "rm -rf ./dist",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "pretest": "npm run compile",
+    "test": "mocha dist/test/runTest.js",
+    "coverage": "c8 npm test",
+    "prepackage": "npm run compile",
+    "package": "vsce package",
     "vscode:prepublish": "esbuild --bundle --external:vscode --outdir=dist --platform=node --target=node8 source/client.ts"
+  },
+  "c8": {
+    "include": [
+      "source/**/*.ts",
+      "dist/**/*.js"
+    ],
+    "exclude": [
+      "source/test/*",
+      "dist/test/*"
+    ],
+    "reporter": [
+      "text-summary",
+      "html",
+      "lcov"
+    ],
+    "report-dir": ".coverage"
   },
   "version": "1.0.7"
 }

--- a/source/client.ts
+++ b/source/client.ts
@@ -176,11 +176,11 @@ const DEPRECATED_WARNINGS = new Set([
 ]);
 
 function discoverInterpreterMode(
-  cabal: string | undefined,
+  cabal: string | null,
   cabalProject: vscode.Uri | undefined, // cabal.project
   cabalPackage: vscode.Uri | undefined, // *.cabal
-  ghci: string | undefined,
-  stack: string | undefined,
+  ghci: string | null,
+  stack: string | null,
   stackProject: vscode.Uri | undefined, // stack.yaml
   stackPackage: vscode.Uri | undefined // package.yaml
 ): InterpreterMode {
@@ -283,9 +283,9 @@ async function setInterpreterTemplate(
 }
 
 function discoverHaskellFormatterMode(
-  fourmolu: string | undefined,
+  fourmolu: string | null,
   fourmoluConfig: vscode.Uri | undefined,
-  ormolu: string | undefined,
+  ormolu: string | null,
   ormoluConfig: vscode.Uri | undefined
 ): HaskellFormatterMode {
   if (fourmolu && !ormolu) {
@@ -366,7 +366,7 @@ async function setHaskellFormatterTemplate(
 }
 
 function discoverHaskellLinterMode(
-  hlint: string | undefined
+  hlint: string | null
 ): HaskellLinterMode {
   if (hlint) {
     return HaskellLinterMode.Hlint;
@@ -415,8 +415,8 @@ async function setHaskellLinterTemplate(
 }
 
 function discoverCabalFormatterMode(
-  cabalFmt: string | undefined,
-  gild: string | undefined
+  cabalFmt: string | null,
+  gild: string | null
 ): CabalFormatterMode {
   if (gild) {
     return CabalFormatterMode.Gild;

--- a/source/test/index.ts
+++ b/source/test/index.ts
@@ -1,0 +1,37 @@
+import * as path from 'path';
+import { glob } from 'glob';
+import Mocha from 'mocha';
+
+
+export async function run(): Promise<void> {
+	// Create the mocha test
+	const mocha = new Mocha({
+		ui: 'tdd',
+		timeout: 30000,
+		color: true
+	});
+
+	const testsRoot = __dirname;
+
+	return new Promise((c, e) => {
+		glob('**/**.test.js', { cwd: testsRoot }, (_, files) => {
+
+            // Add files to the test suite
+            files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+
+            try {
+                // Run the mocha test
+                mocha.run(failures => {
+                    if (failures > 0) {
+                        e(new Error(`${failures} tests failed.`));
+                    } else {
+                        c();
+                    }
+                });
+            } catch (err) {
+                console.error(err);
+                e(err);
+            }
+        })
+    });        
+}

--- a/source/test/providers.test.ts
+++ b/source/test/providers.test.ts
@@ -1,0 +1,48 @@
+import * as vscode from 'vscode';
+import { runFileTest } from './utils';
+import { DiagnosticSeverity } from 'vscode';
+import { assert } from 'chai';
+
+
+const settings = new Map(Object.entries({
+  'telemetry.enableTelemetry': false,
+  'purple-yolk.haskell.interpreter.command': 'stack ghci ${file} --ghci-options "-ddump-json -Wall"',
+}));
+
+suite('', () => {
+  suiteSetup(async () => {
+    const config = vscode.workspace.getConfiguration();
+    for (const [setting, value] of settings) { 
+      await config.update(setting, value, true);
+    }
+
+    await vscode.commands.executeCommand('workbench.actions.view.problems');
+    await vscode.commands.executeCommand('workbench.action.positionPanelRight');
+  });
+  
+  test('OK (no diagnostics)', () => {
+      return runFileTest('OK.hs', 0, async () => {
+    });
+  });
+
+  test('Warning only', () => {
+    return runFileTest('Warning.hs', 1, async (_, diags) => {
+      assert.lengthOf(diags, 1);
+      assert.include(diags[0]?.message, 'Top-level binding with no type signature');
+    });
+  });
+
+  test('Error only', () => {
+    return runFileTest('Error.hs', [DiagnosticSeverity.Error, 1], async (_, diags) => {
+      assert.lengthOf(diags, 1);
+      assert.include(diags[0]?.message, 'Not in scope: type constructor or class');
+    });
+  });
+
+  suiteTeardown(async () => {
+    const config = vscode.workspace.getConfiguration();
+    for (const setting in settings) { 
+      await config.update(setting, undefined, true);
+    }
+  });
+});

--- a/source/test/runTest.ts
+++ b/source/test/runTest.ts
@@ -1,0 +1,72 @@
+import * as cp from 'child_process';
+import * as path from 'path';
+import { env } from 'process';
+
+import {
+  runTests,
+  downloadAndUnzipVSCode,
+  resolveCliPathFromVSCodeExecutablePath
+} from '@vscode/test-electron';
+
+async function main(): Promise<number> {
+  try {
+    // The folder containing the Extension Manifest package.json
+    // Passed to `--extensionDevelopmentPath`
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+
+    // The path to the extension test runner script
+    // Passed to --extensionTestsPath
+    const extensionTestsPath = __dirname;
+    const vscodeVersion = env['CODE_VERSION'];
+    const vscodeExecutablePath = await downloadAndUnzipVSCode(vscodeVersion);
+    const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
+
+    // Install dependent extensions
+    const dependencies = [
+      'justusadam.language-haskell',
+    ];
+
+    const extensionsDir = path.resolve(path.dirname(cliPath), '..', '..', 'extensions');
+    const userDataDir = path.resolve(extensionsDir, '..', 'udd');
+
+    for(const extension of dependencies) {
+      cp.spawnSync(cliPath, ['--extensions-dir', extensionsDir, '--user-data-dir', userDataDir, '--install-extension', extension], {
+        shell: process.platform === 'win32',
+        encoding: 'utf-8',
+        stdio: 'inherit'
+      });
+    }
+
+    // This is required for Mocha tests to report non-zero exit code in case of test failure
+    process.removeAllListeners('exit');
+
+    // Download VS Code, unzip it and run all integration tests
+    return await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--user-data-dir', userDataDir,
+        '--extensions-dir', extensionsDir,
+        '--logExtensionHostCommunication',
+        '--new-window',
+        '--disable-gpu',
+        '--disable-updates',
+        '--disable-telemetry',
+        '--disable-workspace-trust',
+        '--do-not-sync',
+        '--skip-add-to-recently-opened',
+        '--skip-welcome',
+        '--skip-release-notes',
+        '--use-inmemory-secretstorage',
+        '--wait',
+      ]
+    });
+  } catch (err) {
+    console.error(err);
+    console.error('Failed to run tests');
+    process.exit(1);
+  }
+}
+
+main();

--- a/source/test/utils.ts
+++ b/source/test/utils.ts
@@ -1,0 +1,63 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { TextDocument, Disposable, DiagnosticSeverity } from 'vscode';
+import { assert } from 'chai';
+
+export type DocFun = (doc: TextDocument) => Thenable<void>;
+export type AssertFun = (doc: TextDocument, diags: vscode.Diagnostic[]) => Thenable<void>;
+
+export function runFileTest(file: string, diagsCount: number|[DiagnosticSeverity, number], asserts: AssertFun): Promise<void> {
+  const [severety, count] = typeof diagsCount === 'number' ? [DiagnosticSeverity.Warning, diagsCount] : diagsCount;
+  return withTestDocument(file, [severety, count], async doc => {
+    const diagnostics = vscode.languages.getDiagnostics(doc.uri);
+    await asserts(doc, diagnostics);
+  });
+}
+
+export async function withTestDocument(filePath: string, diagnosticCount: [DiagnosticSeverity, number], test: DocFun, cleanup?: DocFun): Promise<void> { 
+  const file = path.join(__dirname, '../../data/test', filePath);
+  const doc = await didChangeDiagnostics(file, diagnosticCount, async () => {
+    const doc = await vscode.workspace.openTextDocument(file);
+    await vscode.window.showTextDocument(doc, { preview: false });
+    await vscode.commands.executeCommand('purple-yolk.haskell.interpret');
+    return doc;
+  });
+  try {
+    await test(doc);
+  } finally {
+    await cleanup?.(doc);
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+  }
+}
+
+export async function didChangeDiagnostics<T>(fsPath: string, [severety, count]: [DiagnosticSeverity, number], action: () => Thenable<T>) {
+    return didEvent(
+      vscode.languages.onDidChangeDiagnostics,
+      e => {
+        const uri = e.uris.find(uri => uri.fsPath === fsPath);
+        if (uri) {
+          const diags = vscode.languages.getDiagnostics(uri).filter(d => d.severity <= severety);
+          assert.isAtMost(diags.length, count);
+          return diags.length === count;
+        } else {
+          return false;
+        }
+      },
+      action,
+    );
+}
+
+export async function didEvent<TResult, TEvent>(
+  subscribe: (arg: (event: TEvent) => void) => Disposable,
+  predicate: (event: TEvent) => Boolean,
+  action: () => Thenable<TResult>): Promise<TResult> {
+  return new Promise<TResult>(async (resolve, _) => {
+    const disposable = subscribe(async e => {
+      if(predicate(e)) {
+        disposable.dispose();
+        resolve(await result);
+      }
+    });
+    let result = action();
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "rootDir": "source"
   },
   "extends": [
     "@tsconfig/node18/tsconfig.json",


### PR DESCRIPTION
Not sure if you need it but I thought it might be helpful to have some tests to check basic functionality of Purple York and to run them via matrix build to check for regression.

This change contains three simple tests defined in [providers.test.ts](https://github.com/EduardSergeev/purple-yolk/blob/b4ea411922c2efe9638d1ef680d82bb1eee80864/source/test/providers.test.ts#L23-L40). Each test:

- Loads specified Haskell file (1st test parameter);
- Waits for the extension to populate diagnostics with specified number of error/warnings (2nd test parameter);
- Runs assertion code (3rd parameter) passing loaded `Document` and corresponding `Diagnostic[]`.

E.g. a test which is defined as:

```typescript
  test('Error only', () => {
    return runFileTest('Error.hs', [DiagnosticSeverity.Error, 1], async (_, diags) => {
      assert.lengthOf(diags, 1);
      assert.include(diags[0]?.message, 'Not in scope: type constructor or class');
    });
  });
```

loads [Error.hs](https://github.com/EduardSergeev/purple-yolk/blob/b4ea411922c2efe9638d1ef680d82bb1eee80864/data/test/Error.hs), waits until the extension produces 1 error and then runs the code with those two assertions.

Test suite can be run via

```console
npm test
```

or with test coverage report (produces by [c8](https://github.com/bcoe/c8)):

```console
npm run coverage
```

Current code coverage:

<pre>=============================== Coverage summary ===============================
<font color="#FCE94F"><b>Statements   : 64.83% ( 780/1203 )</b></font>
<font color="#FCE94F"><b>Branches     : 51.96% ( 53/102 )</b></font>
<font color="#FCE94F"><b>Functions    : 62.85% ( 22/35 )</b></font>
<font color="#FCE94F"><b>Lines        : 64.83% ( 780/1203 )</b></font>
================================================================================
</pre>

And one [from CI](https://github.com/tfausak/purple-yolk/actions/runs/9624266921/job/26547751186#step:6:122)

This change also adds matrix build which runs all tests on all supported platforms with various GHC versions. Here is an [example of new CI run](https://github.com/tfausak/purple-yolk/actions/runs/9624266921).
It also [uploads test coverage](https://github.com/EduardSergeev/purple-yolk/blob/b4ea411922c2efe9638d1ef680d82bb1eee80864/.github/workflows/workflow.yaml#L133-L139) to https://coveralls.io, e.g. [recent coverage report](https://coveralls.io/builds/68239035).