### PR TITLE
Add type-on-hover

### DIFF
--- a/source/client.ts
+++ b/source/client.ts
@@ -1164,10 +1164,34 @@ async function provideHover(
     return null;
   }
 
-  // When we know the module, temporarily set GHCi's context to *Foo so that
-  // :type is evaluated against that module's imports and internal names.
-  // Afterward we restore the context to the full set of interpreted modules
-  // that were loaded before the hover.
+  // :type-at gives the instantiated type at a specific location (e.g. "()"),
+  // while :type gives the general type (e.g. "mempty :: Monoid a => a").
+  // We show both when they differ, so the user sees the full picture.
+
+  // :type-at uses file/line/col directly — no module juggling needed.
+  // Requires :set +c (sent at startup).
+  const filePath = vscode.workspace.asRelativePath(document.uri);
+  const sl = wordRange.start.line + 1;
+  const sc = wordRange.start.character + 1;
+  const el = wordRange.end.line + 1;
+  const ec = wordRange.end.character + 1;
+  const typeAtLines = await queryGhci(
+    channel,
+    `:type-at ${filePath} ${sl} ${sc} ${el} ${ec} ${expr}`
+  );
+
+  if (token.isCancellationRequested) {
+    return null;
+  }
+
+  const typeAtResult =
+    typeAtLines &&
+    typeAtLines.length > 0 &&
+    !typeAtLines.some((l) => l.startsWith("<interactive>:"))
+      ? typeAtLines.join("\n")
+      : null;
+
+  // :type needs module context so it can resolve the name.
   //
   // The file→module map is built lazily and cached; it is invalidated on
   // reload (the only time the set of loaded modules changes).
@@ -1194,35 +1218,42 @@ async function provideHover(
     const moduleName = MODULE_CACHE.fileToModule.get(document.uri.fsPath);
     if (moduleName) {
       restoreCmd = MODULE_CACHE.interpretedModules.length > 0
-        ? `:module ${MODULE_CACHE.interpretedModules.map(m => `*${m}`).join(" ")}`
+        ? `:module ${MODULE_CACHE.interpretedModules.join(" ")}`
         : `:module`;
       log(channel, key, `Setting module context: *${moduleName}`);
       await queryGhci(channel, `:module *${moduleName}`);
     }
   }
 
-  const lines = await queryGhci(channel, `:type ${expr}`);
+  const typeLines = await queryGhci(channel, `:type ${expr}`);
 
   if (restoreCmd) {
     log(channel, key, `Restoring module context: ${restoreCmd}`);
     await queryGhci(channel, restoreCmd);
   }
 
-  if (token.isCancellationRequested || !lines || lines.length === 0) {
+  if (token.isCancellationRequested) {
     return null;
   }
 
-  const result = lines.join("\n");
+  const typeResult =
+    typeLines &&
+    typeLines.length > 0 &&
+    !typeLines.some((l) => l.startsWith("<interactive>:"))
+      ? typeLines.join("\n")
+      : null;
 
-  // GHCi errors (e.g. "Variable not in scope") come through stdout starting
-  // with "<interactive>:" — suppress these as hover content.
-  if (result.startsWith("<interactive>:")) {
-    log(channel, key, "GHCi returned an error, suppressing hover.");
+  if (!typeAtResult && !typeResult) {
     return null;
   }
 
   const markdown = new vscode.MarkdownString();
-  markdown.appendCodeblock(result, "haskell");
+  if (typeAtResult && typeResult && typeAtResult !== typeResult) {
+    markdown.appendCodeblock(typeAtResult, "haskell");
+    markdown.appendCodeblock(typeResult, "haskell");
+  } else {
+    markdown.appendCodeblock(typeResult || typeAtResult!, "haskell");
+  }
   return new vscode.Hover(markdown, wordRange);
 }
 
@@ -1333,6 +1364,9 @@ async function startInterpreter(
   const input = `:set prompt "${prompt}\\n"`;
   log(channel, key, `[stdin] ${input}`);
   task.stdin?.write(`${input}\n`);
+
+  // Enable collecting type/location info so that :type-at works.
+  task.stdin?.write(`:set +c\n`);
 
   await new Promise<void>((resolve) => {
     assert.ok(task.stdout);

--- a/source/client.ts
+++ b/source/client.ts
@@ -48,6 +48,8 @@ const DEFAULT_NEW_MESSAGE_SPAN: NewMessageSpan = {
 
 let INTERPRETER: Interpreter | null = null;
 
+let STDOUT_ACCUMULATOR: { lines: string[]; resolve: () => void } | null = null;
+
 let INTERPRETER_TEMPLATE: Template | undefined = undefined;
 
 let HASKELL_FORMATTER_TEMPLATE: Template | undefined = undefined;
@@ -191,6 +193,9 @@ const DEPRECATED_WARNINGS = new Set([
 ]);
 
 const COMPILING_PATTERN = /^\[ *(\d+) of (\d+)\] Compiling ([^ ]+) +\( ([^,]+)/;
+
+const HASKELL_WORD_PATTERN =
+  /[A-Z][A-Za-z0-9_']*(?:\.[A-Z][A-Za-z0-9_']*)*(?:\.[a-z_][A-Za-z0-9_']*)?|[a-z_][A-Za-z0-9_']*|[!#$%&*+./<=>?@\\^|\-~:]+/;
 
 function discoverInterpreterMode(
   cabal: string | null,
@@ -585,6 +590,13 @@ export async function activate(
         formatDocumentRange(languageId, channel, document, range, token),
     });
   });
+
+  context.subscriptions.push(
+    vscode.languages.registerHoverProvider(LanguageId.Haskell, {
+      provideHover: (document, position, token) =>
+        provideHover(channel, document, position, token),
+    })
+  );
 
   await Promise.all([
     setInterpreterTemplate(channel),
@@ -1082,6 +1094,84 @@ async function reloadInterpreter(
   log(channel, key, `Finished reloading in ${elapsed} seconds.`);
 }
 
+async function queryGhci(
+  channel: vscode.OutputChannel,
+  command: string
+): Promise<string[] | null> {
+  const key = newKey();
+  log(channel, key, `Querying GHCi: ${JSON.stringify(command)} ...`);
+
+  if (!INTERPRETER) {
+    log(channel, key, "Error: No interpreter available.");
+    return null;
+  }
+
+  if (INTERPRETER.key) {
+    log(channel, key, `Ignoring because ${INTERPRETER.key} is running.`);
+    return null;
+  }
+
+  INTERPRETER.key = key;
+
+  const lines = await new Promise<string[]>((resolve) => {
+    const accumulator = {
+      lines: [] as string[],
+      resolve: () => resolve(accumulator.lines),
+    };
+    STDOUT_ACCUMULATOR = accumulator;
+    log(channel, key, `[stdin] ${command}`);
+    INTERPRETER!.task.stdin?.write(`${command}\n`);
+  });
+
+  log(channel, key, `Raw output: ${JSON.stringify(lines)}`);
+  return lines;
+}
+
+async function provideHover(
+  channel: vscode.OutputChannel,
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  token: vscode.CancellationToken
+): Promise<vscode.Hover | null> {
+  const key = newKey();
+  log(channel, key, "Providing hover ...");
+
+  const wordRange = document.getWordRangeAtPosition(position, HASKELL_WORD_PATTERN);
+  if (!wordRange) {
+    return null;
+  }
+
+  const word = document.getText(wordRange);
+  if (!word) {
+    return null;
+  }
+
+  // Operators must be parenthesized for :type, identifiers must not.
+  const isOperator = /^[!#$%&*+./<=>?@\\^|\-~:]+$/.test(word);
+  const expr = isOperator ? `(${word})` : word;
+
+  log(channel, key, `Hover word: ${JSON.stringify(word)}, expr: ${JSON.stringify(expr)}`);
+
+  const lines = await queryGhci(channel, `:type ${expr}`);
+
+  if (token.isCancellationRequested || !lines || lines.length === 0) {
+    return null;
+  }
+
+  const result = lines.join("\n");
+
+  // GHCi errors (e.g. "Variable not in scope") come through stdout starting
+  // with "<interactive>:" — suppress these as hover content.
+  if (result.startsWith("<interactive>:")) {
+    log(channel, key, "GHCi returned an error, suppressing hover.");
+    return null;
+  }
+
+  const markdown = new vscode.MarkdownString();
+  markdown.appendCodeblock(result, "haskell");
+  return new vscode.Hover(markdown, wordRange);
+}
+
 // If the given string is an absolute path, then it is returned as a file URI.
 // Otherwise the relative segment is joined with the root URI.
 //
@@ -1194,9 +1284,19 @@ async function startInterpreter(
     readline.createInterface(task.stdout).on("line", (line) => {
       let shouldLog: boolean = true;
 
+      if (STDOUT_ACCUMULATOR && !line.includes(prompt)) {
+        STDOUT_ACCUMULATOR.lines.push(line);
+        return;
+      }
+
       if (line.includes(prompt)) {
         if (INTERPRETER?.key) {
           INTERPRETER.key = null;
+        }
+        if (STDOUT_ACCUMULATOR) {
+          const acc = STDOUT_ACCUMULATOR;
+          STDOUT_ACCUMULATOR = null;
+          acc.resolve();
         }
         resolve();
         updateStatus(status, false, vscode.LanguageStatusSeverity.Information, "Idle");

--- a/source/client.ts
+++ b/source/client.ts
@@ -1173,7 +1173,7 @@ async function provideHover(
     const filePath = document.uri.fsPath;
     const moduleName = moduleLines
       .map(line => {
-        const m = line.match(/^(\S+)\s+\(\s*(.+),\s*(interpreted|compiled)/);
+        const m = line.match(/^(\S+)\s*\(\s*(.+?),\s*(interpreted|compiled)/);
         return m && m[1] && m[2] ? { name: m[1], file: m[2].trim() } : null;
       })
       .filter((e): e is { name: string; file: string } => e !== null)

--- a/source/client.ts
+++ b/source/client.ts
@@ -50,6 +50,13 @@ let INTERPRETER: Interpreter | null = null;
 
 let STDOUT_ACCUMULATOR: { lines: string[]; resolve: () => void } | null = null;
 
+type ModuleCache = {
+  fileToModule: Map<string, string>; // absolute path → module name
+  interpretedModules: string[];      // names of all interpreted modules
+};
+
+let MODULE_CACHE: ModuleCache | null = null;
+
 let INTERPRETER_TEMPLATE: Template | undefined = undefined;
 
 let HASKELL_FORMATTER_TEMPLATE: Template | undefined = undefined;
@@ -1073,6 +1080,7 @@ async function reloadInterpreter(
   }
 
   INTERPRETER.key = key;
+  MODULE_CACHE = null;
 
   updateStatus(status, true, vscode.LanguageStatusSeverity.Information, "Loading");
 
@@ -1160,29 +1168,33 @@ async function provideHover(
   // :type is evaluated against that module's imports and internal names.
   // Afterward we restore the context to the full set of interpreted modules
   // that were loaded before the hover.
-  let restoreCmd: string | null = null;
-  const moduleLines = await queryGhci(channel, ":show modules");
-  if (moduleLines !== null) {
-    const interpretedModules = moduleLines
-      .filter(line => line.includes(", interpreted"))
-      .map(line => line.match(/^(\S+)/)?.[1])
-      .filter((name): name is string => name !== undefined);
-
-    // Look up the module name for this document from GHCi's own file→module
-    // mapping. Each `:show modules` line is: `ModuleName  ( filepath, ... )`.
-    const filePath = document.uri.fsPath;
-    const moduleName = moduleLines
-      .map(line => {
+  //
+  // The file→module map is built lazily and cached; it is invalidated on
+  // reload (the only time the set of loaded modules changes).
+  if (MODULE_CACHE === null) {
+    const moduleLines = await queryGhci(channel, ":show modules");
+    if (moduleLines !== null) {
+      const fileToModule = new Map<string, string>();
+      const interpretedModules: string[] = [];
+      for (const line of moduleLines) {
         const m = line.match(/^(\S+)\s*\(\s*(.+?),\s*(interpreted|compiled)/);
-        return m && m[1] && m[2] ? { name: m[1], file: m[2].trim() } : null;
-      })
-      .filter((e): e is { name: string; file: string } => e !== null)
-      .find(e => path.resolve(e.file) === filePath)
-      ?.name;
+        if (m && m[1] && m[2]) {
+          fileToModule.set(path.resolve(m[2].trim()), m[1]);
+          if (m[3] === "interpreted") {
+            interpretedModules.push(m[1]);
+          }
+        }
+      }
+      MODULE_CACHE = { fileToModule, interpretedModules };
+    }
+  }
 
+  let restoreCmd: string | null = null;
+  if (MODULE_CACHE !== null) {
+    const moduleName = MODULE_CACHE.fileToModule.get(document.uri.fsPath);
     if (moduleName) {
-      restoreCmd = interpretedModules.length > 0
-        ? `:module ${interpretedModules.map(m => `*${m}`).join(" ")}`
+      restoreCmd = MODULE_CACHE.interpretedModules.length > 0
+        ? `:module ${MODULE_CACHE.interpretedModules.map(m => `*${m}`).join(" ")}`
         : `:module`;
       log(channel, key, `Setting module context: *${moduleName}`);
       await queryGhci(channel, `:module *${moduleName}`);
@@ -1256,6 +1268,7 @@ async function startInterpreter(
     log(channel, key, `Stopping interpreter ${INTERPRETER.task.pid} ...`);
     INTERPRETER.task.kill();
     INTERPRETER = null;
+    MODULE_CACHE = null;
     collection.clear();
   }
 

--- a/source/client.ts
+++ b/source/client.ts
@@ -1152,7 +1152,49 @@ async function provideHover(
 
   log(channel, key, `Hover word: ${JSON.stringify(word)}, expr: ${JSON.stringify(expr)}`);
 
+  if (token.isCancellationRequested) {
+    return null;
+  }
+
+  // When we know the module, temporarily set GHCi's context to *Foo so that
+  // :type is evaluated against that module's imports and internal names.
+  // Afterward we restore the context to the full set of interpreted modules
+  // that were loaded before the hover.
+  let restoreCmd: string | null = null;
+  const moduleLines = await queryGhci(channel, ":show modules");
+  if (moduleLines !== null) {
+    const interpretedModules = moduleLines
+      .filter(line => line.includes(", interpreted"))
+      .map(line => line.match(/^(\S+)/)?.[1])
+      .filter((name): name is string => name !== undefined);
+
+    // Look up the module name for this document from GHCi's own file→module
+    // mapping. Each `:show modules` line is: `ModuleName  ( filepath, ... )`.
+    const filePath = document.uri.fsPath;
+    const moduleName = moduleLines
+      .map(line => {
+        const m = line.match(/^(\S+)\s+\(\s*(.+),\s*(interpreted|compiled)/);
+        return m && m[1] && m[2] ? { name: m[1], file: m[2].trim() } : null;
+      })
+      .filter((e): e is { name: string; file: string } => e !== null)
+      .find(e => path.resolve(e.file) === filePath)
+      ?.name;
+
+    if (moduleName) {
+      restoreCmd = interpretedModules.length > 0
+        ? `:module ${interpretedModules.map(m => `*${m}`).join(" ")}`
+        : `:module`;
+      log(channel, key, `Setting module context: *${moduleName}`);
+      await queryGhci(channel, `:module *${moduleName}`);
+    }
+  }
+
   const lines = await queryGhci(channel, `:type ${expr}`);
+
+  if (restoreCmd) {
+    log(channel, key, `Restoring module context: ${restoreCmd}`);
+    await queryGhci(channel, restoreCmd);
+  }
 
   if (token.isCancellationRequested || !lines || lines.length === 0) {
     return null;


### PR DESCRIPTION
Registers a HoverProvider for Haskell that queries the running GHCi session with :type when the user hovers over an identifier or operator, displaying the result in a Haskell code block.

Introduces a generic queryGhci() primitive that routes stdout output into an accumulator until the sentinel prompt fires, so future features (e.g. :doc, :complete) can reuse the same infrastructure.